### PR TITLE
build(ops): split gqa attention launchers into per-dtype translation units

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,11 @@ add_library(ninfer_ops STATIC
   ops/launcher/bidirectional_gqa_attention.cu
   ops/launcher/swa.cu
   ops/launcher/gqa_attention_decode.cu
+  ops/launcher/gqa_attention_decode_bf16.cu
+  ops/launcher/gqa_attention_decode_i8.cu
   ops/launcher/gqa_attention_prefill.cu
+  ops/launcher/gqa_attention_prefill_bf16.cu
+  ops/launcher/gqa_attention_prefill_i8.cu
   ops/launcher/kv_cache_append_prefix.cu
   ops/launcher/l2norm.cu
   ops/launcher/layer_norm.cu

--- a/src/ops/launcher/gqa_attention.h
+++ b/src/ops/launcher/gqa_attention.h
@@ -26,6 +26,44 @@ struct GqaSmallTInvocation {
 std::int32_t gqa_attention_split_capacity(std::int32_t q_heads, std::int32_t tokens,
                                           DType cache_dtype, GqaExecutionEnvelope envelope);
 
+// Per-dtype kernel launch routes. Each route lives in its own translation unit
+// (gqa_attention_{decode,prefill}_<dtype>.cu) so the fat kernel families
+// compile in parallel; every route is explicitly instantiated there for both
+// geometries and both cache-input modes, so callers see declarations only.
+// The compressed-KV packing/codec variant is selected inside the i8 route from
+// the cache view flags (packed_v / packed_k / e8_lattice / e8_root).
+template <typename Geometry, typename CacheInput>
+void gqa_small_t_partial_bf16(const Tensor& q, CacheInput input, const Tensor& pos, float scale,
+                              PagedKVBatchLayerView cache, const GqaSmallTInvocation& invocation,
+                              std::int32_t logical_capacity, std::int32_t splits,
+                              Tensor& partial_acc, Tensor& partial_m, Tensor& partial_l,
+                              cudaStream_t stream);
+
+template <typename Geometry, typename CacheInput>
+void gqa_small_t_partial_i8(const Tensor& q, CacheInput input, const Tensor& pos, float scale,
+                            PagedKVBatchLayerView cache, const GqaSmallTInvocation& invocation,
+                            std::int32_t logical_capacity, std::int32_t implementation_window,
+                            std::int32_t splits, Tensor& partial_acc, Tensor& partial_m,
+                            Tensor& partial_l, cudaStream_t stream);
+
+template <typename Geometry, typename CacheView, typename Metadata>
+void gqa_prefill_attention_bf16(const Tensor& q, const Tensor& positions, float scale,
+                                const CacheView& cache, Metadata metadata, Tensor& out,
+                                cudaStream_t stream);
+
+template <typename Geometry, typename CacheView, typename Metadata>
+void gqa_prefill_attention_i8(const Tensor& q, const Tensor& positions, float scale,
+                              const CacheView& cache, Metadata metadata, Tensor& out,
+                              cudaStream_t stream);
+
+template <typename Geometry, typename CacheView, typename Metadata>
+void gqa_prefill_append_bf16(const Tensor& k, const Tensor& v, const Tensor& positions,
+                             CacheView cache, Metadata metadata, cudaStream_t stream);
+
+template <typename Geometry, typename CacheView, typename Metadata>
+void gqa_prefill_append_i8(const Tensor& k, const Tensor& v, const Tensor& positions,
+                           CacheView cache, Metadata metadata, cudaStream_t stream);
+
 bool gqa_attention_uses_small_t(std::int32_t tokens);
 
 GqaAttentionRoute gqa_attention_resolve_route(std::int32_t q_heads, std::int32_t width,

--- a/src/ops/launcher/gqa_attention_decode.cu
+++ b/src/ops/launcher/gqa_attention_decode.cu
@@ -1,12 +1,12 @@
-// ninfer::ops - split-KV GQA small-T launcher and unified route dispatcher.
+// ninfer::ops - split-KV GQA small-T dispatcher: host split policy, dtype route
+// selection, and the split reducer. The per-dtype partial kernels live in
+// gqa_attention_decode_{bf16,i8}.cu.
 #include "ops/launcher/gqa_attention.h"
 
 #include "ops/common/math.h"
 #include "ops/kernel/gqa_attention_decode.cuh"
-#include "ops/kernel/gqa_attention_decode_bf16.cuh"
-#include "ops/kernel/gqa_attention_decode_i8.cuh"
+#include "ops/kernel/gqa_attention_kv_quant.cuh"
 #include "core/device.h" // CUDA_CHECK
-#include "ninfer/ops/gqa_attention.h"
 
 #include <cstdint>
 #include <stdexcept>
@@ -82,127 +82,6 @@ std::int32_t gqa_small_t_launch_capacity(GqaExecutionEnvelope envelope, std::int
     return capacity;
 }
 
-template <typename Geometry, int TokenTile, int WarpsPerCta, bool MultiBatch, bool Masked,
-          typename CacheInput>
-void launch_tc_partial_bf16(const Tensor& q, CacheInput input, const Tensor& pos, float scale,
-                            PagedKVBatchLayerView cache, const GqaSmallTInvocation& invocation,
-                            std::int32_t logical_capacity, std::int32_t splits, Tensor& partial_acc,
-                            Tensor& partial_m, Tensor& partial_l, cudaStream_t stream) {
-    constexpr int kBlock = 32 * WarpsPerCta;
-    const dim3 grid(Geometry::KVHeads, splits, invocation.batch_size);
-    Tensor& cache_k = cache.k_pages;
-    Tensor& cache_v = cache.v_pages;
-    // bf16 kernel uses only static smem (no dynamic staging).
-    gqa_attention_small_t_tc_partial_bf16_kernel<Geometry, TokenTile, WarpsPerCta, MultiBatch,
-                                                 Masked, CacheInput><<<grid, kBlock, 0, stream>>>(
-        static_cast<const __nv_bfloat16*>(q.data), input,
-        static_cast<const std::int32_t*>(pos.data), static_cast<__nv_bfloat16*>(cache_k.data),
-        static_cast<__nv_bfloat16*>(cache_v.data),
-        static_cast<const std::int32_t*>(cache.block_tables.data),
-        invocation.valid_columns == nullptr
-            ? nullptr
-            : static_cast<const std::int32_t*>(invocation.valid_columns->data),
-        invocation.table_rows == nullptr
-            ? nullptr
-            : static_cast<const std::int32_t*>(invocation.table_rows->data),
-        cache.block_tables.ne[0], invocation.width, invocation.full_width, invocation.column_begin,
-        logical_capacity, scale, static_cast<__nv_bfloat16*>(partial_acc.data),
-        static_cast<float*>(partial_m.data), static_cast<float*>(partial_l.data));
-    CUDA_CHECK(cudaGetLastError());
-}
-
-template <typename Geometry, int TokenTile, bool PackedV, bool RotateK, bool RotateV,
-          bool PackedK, bool E8Lattice, bool E8Root, bool MultiBatch, bool Masked, typename CacheInput>
-void launch_tc_partial_i8(const Tensor& q, CacheInput input, const Tensor& pos, float scale,
-                          PagedKVBatchLayerView cache, const GqaSmallTInvocation& invocation,
-                          std::int32_t logical_capacity, std::int32_t implementation_window,
-                          std::int32_t splits, Tensor& partial_acc, Tensor& partial_m,
-                          Tensor& partial_l, cudaStream_t stream) {
-    const dim3 grid(Geometry::KVHeads, splits, invocation.batch_size);
-    Tensor& cache_k       = cache.k_pages;
-    Tensor& cache_v       = cache.v_pages;
-    Tensor& cache_k_scale = cache.k_scale_pages;
-    Tensor& cache_v_scale = cache.v_scale_pages;
-    const auto launch =
-        [&]<int WarpsPerCta, int MinBlocksPerSm, int KeyBlock, bool DynamicArena>() {
-        constexpr std::size_t kDynamicBytes =
-            DynamicArena ? static_cast<std::size_t>(4 * KeyBlock * kGqaHeadDim) : 0ULL;
-        if constexpr (DynamicArena) {
-            static const cudaError_t attr = cudaFuncSetAttribute(
-                gqa_attention_decode_i8_tiled_kernel<Geometry, TokenTile, WarpsPerCta,
-                                                     MinBlocksPerSm, KeyBlock, DynamicArena,
-                                                     PackedV, RotateK, RotateV, PackedK,
-                                                     E8Lattice, E8Root, MultiBatch, Masked, CacheInput>,
-                cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(kDynamicBytes));
-            CUDA_CHECK(attr);
-        }
-        gqa_attention_decode_i8_tiled_kernel<Geometry, TokenTile, WarpsPerCta, MinBlocksPerSm,
-                                             KeyBlock, DynamicArena, PackedV, RotateK, RotateV,
-                                             PackedK, E8Lattice, E8Root, MultiBatch, Masked, CacheInput>
-            <<<grid, WarpsPerCta * 32, kDynamicBytes, stream>>>(
-                static_cast<const __nv_bfloat16*>(q.data), input,
-                static_cast<const std::int32_t*>(pos.data), static_cast<std::int8_t*>(cache_k.data),
-                static_cast<std::uint8_t*>(cache_v.data), static_cast<__half*>(cache_k_scale.data),
-                static_cast<__half*>(cache_v_scale.data),
-                static_cast<const std::int32_t*>(cache.block_tables.data),
-                invocation.valid_columns == nullptr
-                    ? nullptr
-                    : static_cast<const std::int32_t*>(invocation.valid_columns->data),
-                invocation.table_rows == nullptr
-                    ? nullptr
-                    : static_cast<const std::int32_t*>(invocation.table_rows->data),
-                cache.block_tables.ne[0], invocation.full_width, invocation.column_begin,
-                logical_capacity, scale, static_cast<__nv_bfloat16*>(partial_acc.data),
-                static_cast<float*>(partial_m.data), static_cast<float*>(partial_l.data));
-    };
-    if constexpr (TokenTile == 6) {
-        // Small grids need more warps per CTA. From 2K to 8K, Bc=64 halves key
-        // loop iterations; dynamic smem avoids penalizing the long-context path.
-        if (implementation_window > 128 && implementation_window <= 160) {
-            launch.template operator()<24, 1, 32, false>();
-        } else if (implementation_window <= 2054) {
-            launch.template operator()<12, 1, 32, false>();
-        } else if (implementation_window <= 8198) {
-            launch.template operator()<12, 1, 64, true>();
-        } else {
-            launch.template operator()<6, 2, 32, false>();
-        }
-    } else if constexpr (TokenTile == 5) {
-        if constexpr (Geometry::GroupSize == 6) {
-            // Two Q row tiles for the 27B group of six.
-            if (implementation_window > 128 && implementation_window <= 512) {
-                launch.template operator()<32, 1, 32, false>();
-            } else if (implementation_window <= 1029) {
-                launch.template operator()<16, 1, 32, false>();
-            } else {
-                launch.template operator()<8, 2, 32, false>();
-            }
-        } else {
-            // Three Q row tiles for the 35B group of eight. The 24/12-warp
-            // routes retain eight/four consumer warps per tile; the 6-warp
-            // route is reserved for long windows where CTA residency wins.
-            if (implementation_window > 128 && implementation_window <= 512) {
-                launch.template operator()<24, 1, 32, false>();
-            } else if (implementation_window <= 1029) {
-                launch.template operator()<24, 1, 32, false>();
-            } else if (implementation_window <= 4096) {
-                launch.template operator()<12, 1, 32, false>();
-            } else {
-                launch.template operator()<6, 2, 32, false>();
-            }
-        }
-    } else if constexpr (TokenTile == 4) {
-        if (implementation_window <= 1029) {
-            launch.template operator()<16, 1, 32, false>();
-        } else {
-            launch.template operator()<8, 2, 32, false>();
-        }
-    } else {
-        launch.template operator()<8, 2, 32, false>();
-    }
-    CUDA_CHECK(cudaGetLastError());
-}
-
 PagedKVBatchLayerView single_row_batch_view(const PagedKVLayerView& cache) {
     return {
         .k_pages       = cache.k_pages,
@@ -255,81 +134,21 @@ void gqa_attention_small_t_launch_for(const Tensor& q, CacheInput input, const T
     const auto splits =
         gqa_small_t_launch_capacity<Geometry>(envelope, invocation.width, cache.dtype);
 
-    // BF16 keeps its row-tile warp count; INT8 selects its producer/consumer
-    // geometry inside launch_tc_partial_i8.
-#define NINFER_GQA_SMALL_T_DISPATCH(TOKENS, WARPS)                                                 \
-    do {                                                                                           \
-        const auto launch_profile = [&]<bool MultiBatch, bool Masked>() {                          \
-            if (cache.dtype == DType::I8) {                                                        \
-                if (cache.e8_root) {                                                               \
-                    launch_tc_partial_i8<Geometry, (TOKENS), true, true, true, false, false, true,  \
-                                         MultiBatch, Masked>(                                      \
-                        q, input, pos, scale, cache, invocation, logical_capacity,                 \
-                        implementation_window, splits, partial_acc, partial_m, partial_l, stream); \
-                } else if (cache.e8_lattice) {                                                     \
-                    launch_tc_partial_i8<Geometry, (TOKENS), true, true, true, true, true, false,  \
-                                         MultiBatch, Masked>(                                      \
-                        q, input, pos, scale, cache, invocation, logical_capacity,                 \
-                        implementation_window, splits, partial_acc, partial_m, partial_l, stream); \
-                } else if (cache.packed_k) {                                                       \
-                    launch_tc_partial_i8<Geometry, (TOKENS), true, true, true, true, false, false, \
-                                         MultiBatch, Masked>(                                      \
-                        q, input, pos, scale, cache, invocation, logical_capacity,                 \
-                        implementation_window, splits, partial_acc, partial_m, partial_l, stream); \
-                } else if (cache.packed_v) {                                                       \
-                    launch_tc_partial_i8<Geometry, (TOKENS), true, true, true, false, false, false,\
-                                         MultiBatch, Masked>(                                      \
-                        q, input, pos, scale, cache, invocation, logical_capacity,                 \
-                        implementation_window, splits, partial_acc, partial_m, partial_l, stream); \
-                } else {                                                                           \
-                    launch_tc_partial_i8<Geometry, (TOKENS), false, false, false, false, false,    \
-                                         false, MultiBatch, Masked>(                               \
-                        q, input, pos, scale, cache, invocation, logical_capacity,                 \
-                        implementation_window, splits, partial_acc, partial_m, partial_l, stream); \
-                }                                                                                  \
-            } else {                                                                               \
-                launch_tc_partial_bf16<Geometry, (TOKENS), (WARPS), MultiBatch, Masked>(           \
-                    q, input, pos, scale, cache, invocation, logical_capacity, splits,             \
-                    partial_acc, partial_m, partial_l, stream);                                    \
-            }                                                                                      \
-        };                                                                                         \
-        const bool masked = invocation.valid_columns != nullptr;                                   \
-        if (invocation.batch_size == 1) {                                                          \
-            if (masked) {                                                                          \
-                launch_profile.template operator()<false, true>();                                 \
-            } else {                                                                               \
-                launch_profile.template operator()<false, false>();                                \
-            }                                                                                      \
-        } else if (masked) {                                                                       \
-            launch_profile.template operator()<true, true>();                                      \
-        } else {                                                                                   \
-            launch_profile.template operator()<true, false>();                                     \
-        }                                                                                          \
-    } while (0)
-
-    switch (invocation.width) {
-    case 1:
-        NINFER_GQA_SMALL_T_DISPATCH(1, 2);
-        break;
-    case 2:
-        NINFER_GQA_SMALL_T_DISPATCH(2, 4);
-        break;
-    case 3:
-        NINFER_GQA_SMALL_T_DISPATCH(3, 4);
-        break;
-    case 4:
-        NINFER_GQA_SMALL_T_DISPATCH(4, 4);
-        break;
-    case 5:
-        NINFER_GQA_SMALL_T_DISPATCH(5, 4);
-        break;
-    case 6:
-        NINFER_GQA_SMALL_T_DISPATCH(6, 4);
-        break;
-    default:
+    if (invocation.width < 1 || invocation.width > 6) {
         throw std::invalid_argument("gqa_attention_small_t_launch: unsupported T");
     }
-#undef NINFER_GQA_SMALL_T_DISPATCH
+
+    // BF16 keeps its row-tile warp count; INT8 selects its producer/consumer
+    // geometry and its compressed-KV packing inside the i8 route.
+    if (cache.dtype == DType::I8) {
+        gqa_small_t_partial_i8<Geometry, CacheInput>(
+            q, input, pos, scale, cache, invocation, logical_capacity, implementation_window,
+            splits, partial_acc, partial_m, partial_l, stream);
+    } else {
+        gqa_small_t_partial_bf16<Geometry, CacheInput>(q, input, pos, scale, cache, invocation,
+                                                       logical_capacity, splits, partial_acc,
+                                                       partial_m, partial_l, stream);
+    }
 
     constexpr int kReduceBlock = 256;
     constexpr int kDChunk      = 64;

--- a/src/ops/launcher/gqa_attention_decode_bf16.cu
+++ b/src/ops/launcher/gqa_attention_decode_bf16.cu
@@ -1,0 +1,115 @@
+// ninfer::ops - BF16 small-T partial-kernel route. Split from the unified
+// dispatcher so this kernel family compiles in its own translation unit.
+#include "ops/launcher/gqa_attention.h"
+
+#include "ops/kernel/gqa_attention_decode_bf16.cuh"
+#include "core/device.h" // CUDA_CHECK
+
+#include <cstdint>
+#include <stdexcept>
+
+namespace ninfer::ops::detail {
+namespace {
+
+template <typename Geometry, int TokenTile, int WarpsPerCta, bool MultiBatch, bool Masked,
+          typename CacheInput>
+void launch_tc_partial_bf16(const Tensor& q, CacheInput input, const Tensor& pos, float scale,
+                            PagedKVBatchLayerView cache, const GqaSmallTInvocation& invocation,
+                            std::int32_t logical_capacity, std::int32_t splits, Tensor& partial_acc,
+                            Tensor& partial_m, Tensor& partial_l, cudaStream_t stream) {
+    constexpr int kBlock = 32 * WarpsPerCta;
+    const dim3 grid(Geometry::KVHeads, splits, invocation.batch_size);
+    Tensor& cache_k = cache.k_pages;
+    Tensor& cache_v = cache.v_pages;
+    // bf16 kernel uses only static smem (no dynamic staging).
+    gqa_attention_small_t_tc_partial_bf16_kernel<Geometry, TokenTile, WarpsPerCta, MultiBatch,
+                                                 Masked, CacheInput><<<grid, kBlock, 0, stream>>>(
+        static_cast<const __nv_bfloat16*>(q.data), input,
+        static_cast<const std::int32_t*>(pos.data), static_cast<__nv_bfloat16*>(cache_k.data),
+        static_cast<__nv_bfloat16*>(cache_v.data),
+        static_cast<const std::int32_t*>(cache.block_tables.data),
+        invocation.valid_columns == nullptr
+            ? nullptr
+            : static_cast<const std::int32_t*>(invocation.valid_columns->data),
+        invocation.table_rows == nullptr
+            ? nullptr
+            : static_cast<const std::int32_t*>(invocation.table_rows->data),
+        cache.block_tables.ne[0], invocation.width, invocation.full_width, invocation.column_begin,
+        logical_capacity, scale, static_cast<__nv_bfloat16*>(partial_acc.data),
+        static_cast<float*>(partial_m.data), static_cast<float*>(partial_l.data));
+    CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace
+
+template <typename Geometry, typename CacheInput>
+void gqa_small_t_partial_bf16(const Tensor& q, CacheInput input, const Tensor& pos, float scale,
+                              PagedKVBatchLayerView cache, const GqaSmallTInvocation& invocation,
+                              std::int32_t logical_capacity, std::int32_t splits,
+                              Tensor& partial_acc, Tensor& partial_m, Tensor& partial_l,
+                              cudaStream_t stream) {
+    // BF16 keeps its row-tile warp count (2 warps at T=1, 4 warps above).
+#define NINFER_GQA_SMALL_T_BF16_DISPATCH(TOKENS, WARPS)                                             \
+    do {                                                                                           \
+        const auto launch_profile = [&]<bool MultiBatch, bool Masked>() {                          \
+            launch_tc_partial_bf16<Geometry, (TOKENS), (WARPS), MultiBatch, Masked>(               \
+                q, input, pos, scale, cache, invocation, logical_capacity, splits, partial_acc,    \
+                partial_m, partial_l, stream);                                                     \
+        };                                                                                         \
+        const bool masked = invocation.valid_columns != nullptr;                                   \
+        if (invocation.batch_size == 1) {                                                          \
+            if (masked) {                                                                          \
+                launch_profile.template operator()<false, true>();                                 \
+            } else {                                                                               \
+                launch_profile.template operator()<false, false>();                                \
+            }                                                                                      \
+        } else if (masked) {                                                                       \
+            launch_profile.template operator()<true, true>();                                      \
+        } else {                                                                                   \
+            launch_profile.template operator()<true, false>();                                     \
+        }                                                                                          \
+    } while (0)
+
+    switch (invocation.width) {
+    case 1:
+        NINFER_GQA_SMALL_T_BF16_DISPATCH(1, 2);
+        break;
+    case 2:
+        NINFER_GQA_SMALL_T_BF16_DISPATCH(2, 4);
+        break;
+    case 3:
+        NINFER_GQA_SMALL_T_BF16_DISPATCH(3, 4);
+        break;
+    case 4:
+        NINFER_GQA_SMALL_T_BF16_DISPATCH(4, 4);
+        break;
+    case 5:
+        NINFER_GQA_SMALL_T_BF16_DISPATCH(5, 4);
+        break;
+    case 6:
+        NINFER_GQA_SMALL_T_BF16_DISPATCH(6, 4);
+        break;
+    default:
+        throw std::invalid_argument("gqa_attention_small_t_launch: unsupported T");
+    }
+#undef NINFER_GQA_SMALL_T_BF16_DISPATCH
+}
+
+template void gqa_small_t_partial_bf16<Gqa27Geometry, GqaAppendInput>(
+    const Tensor&, GqaAppendInput, const Tensor&, float, PagedKVBatchLayerView,
+    const GqaSmallTInvocation&, std::int32_t, std::int32_t, Tensor&, Tensor&, Tensor&,
+    cudaStream_t);
+template void gqa_small_t_partial_bf16<Gqa27Geometry, GqaCachedInput>(
+    const Tensor&, GqaCachedInput, const Tensor&, float, PagedKVBatchLayerView,
+    const GqaSmallTInvocation&, std::int32_t, std::int32_t, Tensor&, Tensor&, Tensor&,
+    cudaStream_t);
+template void gqa_small_t_partial_bf16<Gqa35Geometry, GqaAppendInput>(
+    const Tensor&, GqaAppendInput, const Tensor&, float, PagedKVBatchLayerView,
+    const GqaSmallTInvocation&, std::int32_t, std::int32_t, Tensor&, Tensor&, Tensor&,
+    cudaStream_t);
+template void gqa_small_t_partial_bf16<Gqa35Geometry, GqaCachedInput>(
+    const Tensor&, GqaCachedInput, const Tensor&, float, PagedKVBatchLayerView,
+    const GqaSmallTInvocation&, std::int32_t, std::int32_t, Tensor&, Tensor&, Tensor&,
+    cudaStream_t);
+
+} // namespace ninfer::ops::detail

--- a/src/ops/launcher/gqa_attention_decode_i8.cu
+++ b/src/ops/launcher/gqa_attention_decode_i8.cu
@@ -1,0 +1,195 @@
+// ninfer::ops - INT8 small-T partial-kernel route. Split from the unified
+// dispatcher so this kernel family compiles in its own translation unit. The
+// compressed-KV packing/codec variant (packed_v / packed_k / e8_lattice /
+// e8_root) is selected here from the cache view flags.
+#include "ops/launcher/gqa_attention.h"
+
+#include "ops/kernel/gqa_attention_decode_i8.cuh"
+#include "core/device.h" // CUDA_CHECK
+
+#include <cstdint>
+#include <stdexcept>
+
+namespace ninfer::ops::detail {
+namespace {
+
+template <typename Geometry, int TokenTile, bool PackedV, bool RotateK, bool RotateV,
+          bool PackedK, bool E8Lattice, bool E8Root, bool MultiBatch, bool Masked,
+          typename CacheInput>
+void launch_tc_partial_i8(const Tensor& q, CacheInput input, const Tensor& pos, float scale,
+                          PagedKVBatchLayerView cache, const GqaSmallTInvocation& invocation,
+                          std::int32_t logical_capacity, std::int32_t implementation_window,
+                          std::int32_t splits, Tensor& partial_acc, Tensor& partial_m,
+                          Tensor& partial_l, cudaStream_t stream) {
+    const dim3 grid(Geometry::KVHeads, splits, invocation.batch_size);
+    Tensor& cache_k       = cache.k_pages;
+    Tensor& cache_v       = cache.v_pages;
+    Tensor& cache_k_scale = cache.k_scale_pages;
+    Tensor& cache_v_scale = cache.v_scale_pages;
+    const auto launch =
+        [&]<int WarpsPerCta, int MinBlocksPerSm, int KeyBlock, bool DynamicArena>() {
+        constexpr std::size_t kDynamicBytes =
+            DynamicArena ? static_cast<std::size_t>(4 * KeyBlock * kGqaHeadDim) : 0ULL;
+        if constexpr (DynamicArena) {
+            static const cudaError_t attr = cudaFuncSetAttribute(
+                gqa_attention_decode_i8_tiled_kernel<Geometry, TokenTile, WarpsPerCta,
+                                                     MinBlocksPerSm, KeyBlock, DynamicArena,
+                                                     PackedV, RotateK, RotateV, PackedK,
+                                                     E8Lattice, E8Root, MultiBatch, Masked, CacheInput>,
+                cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(kDynamicBytes));
+            CUDA_CHECK(attr);
+        }
+        gqa_attention_decode_i8_tiled_kernel<Geometry, TokenTile, WarpsPerCta, MinBlocksPerSm,
+                                             KeyBlock, DynamicArena, PackedV, RotateK, RotateV,
+                                             PackedK, E8Lattice, E8Root, MultiBatch, Masked, CacheInput>
+            <<<grid, WarpsPerCta * 32, kDynamicBytes, stream>>>(
+                static_cast<const __nv_bfloat16*>(q.data), input,
+                static_cast<const std::int32_t*>(pos.data), static_cast<std::int8_t*>(cache_k.data),
+                static_cast<std::uint8_t*>(cache_v.data), static_cast<__half*>(cache_k_scale.data),
+                static_cast<__half*>(cache_v_scale.data),
+                static_cast<const std::int32_t*>(cache.block_tables.data),
+                invocation.valid_columns == nullptr
+                    ? nullptr
+                    : static_cast<const std::int32_t*>(invocation.valid_columns->data),
+                invocation.table_rows == nullptr
+                    ? nullptr
+                    : static_cast<const std::int32_t*>(invocation.table_rows->data),
+                cache.block_tables.ne[0], invocation.full_width, invocation.column_begin,
+                logical_capacity, scale, static_cast<__nv_bfloat16*>(partial_acc.data),
+                static_cast<float*>(partial_m.data), static_cast<float*>(partial_l.data));
+    };
+    if constexpr (TokenTile == 6) {
+        // Small grids need more warps per CTA. From 2K to 8K, Bc=64 halves key
+        // loop iterations; dynamic smem avoids penalizing the long-context path.
+        if (implementation_window > 128 && implementation_window <= 160) {
+            launch.template operator()<24, 1, 32, false>();
+        } else if (implementation_window <= 2054) {
+            launch.template operator()<12, 1, 32, false>();
+        } else if (implementation_window <= 8198) {
+            launch.template operator()<12, 1, 64, true>();
+        } else {
+            launch.template operator()<6, 2, 32, false>();
+        }
+    } else if constexpr (TokenTile == 5) {
+        if constexpr (Geometry::GroupSize == 6) {
+            // Two Q row tiles for the 27B group of six.
+            if (implementation_window > 128 && implementation_window <= 512) {
+                launch.template operator()<32, 1, 32, false>();
+            } else if (implementation_window <= 1029) {
+                launch.template operator()<16, 1, 32, false>();
+            } else {
+                launch.template operator()<8, 2, 32, false>();
+            }
+        } else {
+            // Three Q row tiles for the 35B group of eight. The 24/12-warp
+            // routes retain eight/four consumer warps per tile; the 6-warp
+            // route is reserved for long windows where CTA residency wins.
+            if (implementation_window > 128 && implementation_window <= 512) {
+                launch.template operator()<24, 1, 32, false>();
+            } else if (implementation_window <= 1029) {
+                launch.template operator()<24, 1, 32, false>();
+            } else if (implementation_window <= 4096) {
+                launch.template operator()<12, 1, 32, false>();
+            } else {
+                launch.template operator()<6, 2, 32, false>();
+            }
+        }
+    } else if constexpr (TokenTile == 4) {
+        if (implementation_window <= 1029) {
+            launch.template operator()<16, 1, 32, false>();
+        } else {
+            launch.template operator()<8, 2, 32, false>();
+        }
+    } else {
+        launch.template operator()<8, 2, 32, false>();
+    }
+    CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace
+
+template <typename Geometry, typename CacheInput>
+void gqa_small_t_partial_i8(const Tensor& q, CacheInput input, const Tensor& pos, float scale,
+                            PagedKVBatchLayerView cache, const GqaSmallTInvocation& invocation,
+                            std::int32_t logical_capacity, std::int32_t implementation_window,
+                            std::int32_t splits, Tensor& partial_acc, Tensor& partial_m,
+                            Tensor& partial_l, cudaStream_t stream) {
+#define NINFER_GQA_SMALL_T_I8_DISPATCH(TOKENS)                                                      \
+    do {                                                                                           \
+        const auto launch_packing = [&]<bool PackedV, bool RotateK, bool RotateV, bool PackedK,    \
+                                      bool E8Lattice, bool E8Root>() {                             \
+            const auto launch_profile = [&]<bool MultiBatch, bool Masked>() {                      \
+                launch_tc_partial_i8<Geometry, (TOKENS), PackedV, RotateK, RotateV, PackedK,       \
+                                     E8Lattice, E8Root, MultiBatch, Masked>(                       \
+                    q, input, pos, scale, cache, invocation, logical_capacity,                     \
+                    implementation_window, splits, partial_acc, partial_m, partial_l, stream);     \
+            };                                                                                     \
+            const bool masked = invocation.valid_columns != nullptr;                               \
+            if (invocation.batch_size == 1) {                                                      \
+                if (masked) {                                                                      \
+                    launch_profile.template operator()<false, true>();                             \
+                } else {                                                                           \
+                    launch_profile.template operator()<false, false>();                            \
+                }                                                                                  \
+            } else if (masked) {                                                                   \
+                launch_profile.template operator()<true, true>();                                  \
+            } else {                                                                               \
+                launch_profile.template operator()<true, false>();                                 \
+            }                                                                                      \
+        };                                                                                         \
+        if (cache.e8_root) {                                                                       \
+            launch_packing.template operator()<true, true, true, false, false, true>();            \
+        } else if (cache.e8_lattice) {                                                             \
+            launch_packing.template operator()<true, true, true, true, true, false>();             \
+        } else if (cache.packed_k) {                                                               \
+            launch_packing.template operator()<true, true, true, true, false, false>();            \
+        } else if (cache.packed_v) {                                                               \
+            launch_packing.template operator()<true, true, true, false, false, false>();           \
+        } else {                                                                                   \
+            launch_packing.template operator()<false, false, false, false, false, false>();        \
+        }                                                                                          \
+    } while (0)
+
+    switch (invocation.width) {
+    case 1:
+        NINFER_GQA_SMALL_T_I8_DISPATCH(1);
+        break;
+    case 2:
+        NINFER_GQA_SMALL_T_I8_DISPATCH(2);
+        break;
+    case 3:
+        NINFER_GQA_SMALL_T_I8_DISPATCH(3);
+        break;
+    case 4:
+        NINFER_GQA_SMALL_T_I8_DISPATCH(4);
+        break;
+    case 5:
+        NINFER_GQA_SMALL_T_I8_DISPATCH(5);
+        break;
+    case 6:
+        NINFER_GQA_SMALL_T_I8_DISPATCH(6);
+        break;
+    default:
+        throw std::invalid_argument("gqa_attention_small_t_launch: unsupported T");
+    }
+#undef NINFER_GQA_SMALL_T_I8_DISPATCH
+}
+
+template void gqa_small_t_partial_i8<Gqa27Geometry, GqaAppendInput>(
+    const Tensor&, GqaAppendInput, const Tensor&, float, PagedKVBatchLayerView,
+    const GqaSmallTInvocation&, std::int32_t, std::int32_t, std::int32_t, Tensor&, Tensor&,
+    Tensor&, cudaStream_t);
+template void gqa_small_t_partial_i8<Gqa27Geometry, GqaCachedInput>(
+    const Tensor&, GqaCachedInput, const Tensor&, float, PagedKVBatchLayerView,
+    const GqaSmallTInvocation&, std::int32_t, std::int32_t, std::int32_t, Tensor&, Tensor&,
+    Tensor&, cudaStream_t);
+template void gqa_small_t_partial_i8<Gqa35Geometry, GqaAppendInput>(
+    const Tensor&, GqaAppendInput, const Tensor&, float, PagedKVBatchLayerView,
+    const GqaSmallTInvocation&, std::int32_t, std::int32_t, std::int32_t, Tensor&, Tensor&,
+    Tensor&, cudaStream_t);
+template void gqa_small_t_partial_i8<Gqa35Geometry, GqaCachedInput>(
+    const Tensor&, GqaCachedInput, const Tensor&, float, PagedKVBatchLayerView,
+    const GqaSmallTInvocation&, std::int32_t, std::int32_t, std::int32_t, Tensor&, Tensor&,
+    Tensor&, cudaStream_t);
+
+} // namespace ninfer::ops::detail

--- a/src/ops/launcher/gqa_attention_prefill.cu
+++ b/src/ops/launcher/gqa_attention_prefill.cu
@@ -1,10 +1,12 @@
-// ninfer::ops - gqa_attention prompt-scale launcher: fill k/v at device
-// positions then launch causal attention over absolute cached history.
+// ninfer::ops - gqa_attention prompt-scale dispatcher: geometry, metadata, and
+// dtype route selection. The per-dtype kernels live in
+// gqa_attention_prefill_{bf16,i8}.cu; this TU instantiates no fat kernels.
 #include "ops/launcher/gqa_attention.h"
 
 #include "ops/common/math.h"
-#include "ops/kernel/gqa_attention_prefill_bf16.cuh"
-#include "ops/kernel/gqa_attention_prefill_i8.cuh"
+#include "ops/kernel/gqa_attention_prefill_common.cuh"
+#include "ops/kernel/gqa_attention_geometry.cuh"
+#include "ops/kernel/gqa_attention_kv_quant.cuh"
 #include "core/device.h" // CUDA_CHECK
 
 #include <cstdint>
@@ -13,135 +15,35 @@ namespace ninfer::ops::detail {
 namespace {
 
 template <typename Geometry, typename CacheView, typename Metadata>
-void gqa_attention_prompt_attention_launch_for(const Tensor& q, const Tensor& positions,
-                                               float scale, const CacheView& cache,
-                                               Metadata metadata, Tensor& out,
-                                               cudaStream_t stream) {
-    const Tensor& cache_k = cache.k_pages;
-    const Tensor& cache_v = cache.v_pages;
-    // Both dtype-specialized kernels exceed the default 48 KiB dynamic-smem ceiling.
-    static const cudaError_t attr_bf16 =
-        cudaFuncSetAttribute(gqa_attention_prefill_bf16_kernel<Geometry, Metadata>,
-                             cudaFuncAttributeMaxDynamicSharedMemorySize, kGqaPrefillSmemBytes);
-    CUDA_CHECK(attr_bf16);
-    const auto tokens = static_cast<std::int32_t>(q.ne[2]);
+void gqa_prefill_append_route(const Tensor& k, const Tensor& v, const Tensor& positions,
+                              CacheView cache, Metadata metadata, cudaStream_t stream) {
     if (cache.dtype == DType::I8) {
-        const dim3 attention_grid(static_cast<unsigned>(div_up(tokens, kGqaPrefillI8Br)),
-                                  static_cast<unsigned>(Geometry::QHeads), 1u);
-        const Tensor& cache_k_scale = cache.k_scale_pages;
-        const Tensor& cache_v_scale = cache.v_scale_pages;
-        const auto launch_i8 = [&]<bool PackedV, bool RotateK, bool RotateV, bool PackedK, bool E8Root>() {
-            static const cudaError_t attr_i8 = cudaFuncSetAttribute(
-                gqa_attention_prefill_i8_kernel<Geometry, PackedV, RotateK, RotateV, PackedK, E8Root, Metadata>,
-                cudaFuncAttributeMaxDynamicSharedMemorySize, kGqaPrefillI8SmemBytes);
-            CUDA_CHECK(attr_i8);
-            gqa_attention_prefill_i8_kernel<Geometry, PackedV, RotateK, RotateV, PackedK, E8Root, Metadata>
-                <<<attention_grid, kGqaPrefillI8Threads, kGqaPrefillI8SmemBytes, stream>>>(
-                static_cast<const __nv_bfloat16*>(q.data),
-                static_cast<const std::int8_t*>(cache_k.data),
-                static_cast<const std::uint8_t*>(cache_v.data),
-                static_cast<const __half*>(cache_k_scale.data),
-                static_cast<const __half*>(cache_v_scale.data), metadata,
-                static_cast<const std::int32_t*>(positions.data), scale,
-                static_cast<__nv_bfloat16*>(out.data), tokens);
-        };
-        if (cache.e8_root) {
-            launch_i8.template operator()<true, true, true, false, true>();
-        } else if (cache.packed_k) {
-            launch_i8.template operator()<true, true, true, true, false>();
-        } else if (cache.packed_v) {
-            launch_i8.template operator()<true, true, true, false, false>();
-        } else {
-            launch_i8.template operator()<false, false, false, false, false>();
-        }
+        gqa_prefill_append_i8<Geometry, CacheView, Metadata>(k, v, positions, cache, metadata,
+                                                             stream);
     } else {
-        const dim3 attention_grid(static_cast<unsigned>(div_up(tokens, kGqaPrefillBr)),
-                                  static_cast<unsigned>(Geometry::QHeads), 1u);
-        gqa_attention_prefill_bf16_kernel<Geometry, Metadata>
-            <<<attention_grid, kGqaPrefillThreads, kGqaPrefillSmemBytes, stream>>>(
-                static_cast<const __nv_bfloat16*>(q.data),
-                static_cast<const __nv_bfloat16*>(cache_k.data),
-                static_cast<const __nv_bfloat16*>(cache_v.data), metadata,
-                static_cast<const std::int32_t*>(positions.data), scale,
-                static_cast<__nv_bfloat16*>(out.data), tokens);
-    }
-    CUDA_CHECK(cudaGetLastError());
-    if (cache.rotate_v) {
-        gqa_kv_inverse_rotate_output_kernel<Geometry::QHeads>
-            <<<tokens * Geometry::QHeads * kGqaKvQuantGroups, 32, 0, stream>>>(
-                static_cast<__nv_bfloat16*>(out.data), tokens, tokens, 0, nullptr);
-        CUDA_CHECK(cudaGetLastError());
+        gqa_prefill_append_bf16<Geometry, CacheView, Metadata>(k, v, positions, cache, metadata,
+                                                               stream);
     }
 }
 
 template <typename Geometry, typename CacheView, typename Metadata>
-void gqa_kv_append_launch_for(const Tensor& k, const Tensor& v, const Tensor& positions,
-                              CacheView cache, Metadata metadata, cudaStream_t stream) {
-    const auto tokens = static_cast<std::int32_t>(k.ne[2]);
-    Tensor& cache_k   = cache.k_pages;
-    Tensor& cache_v   = cache.v_pages;
+void gqa_prefill_attention_route(const Tensor& q, const Tensor& positions, float scale,
+                                 const CacheView& cache, Metadata metadata, Tensor& out,
+                                 cudaStream_t stream) {
     if (cache.dtype == DType::I8) {
-        Tensor& cache_k_scale    = cache.k_scale_pages;
-        Tensor& cache_v_scale    = cache.v_scale_pages;
-        constexpr int kFillBlock = 256;
-        const auto launch_fill = [&]<bool PackedV, bool RotateK, bool RotateV, bool PackedK, bool E8Lattice, bool E8Root>() {
-        if (tokens >= 32) {
-            constexpr int kPageBlock     = 256;
-            constexpr int kTokensPerTile = 8;
-            const int max_tiles          = static_cast<int>(div_up(tokens + kTokensPerTile, kTokensPerTile));
-            const dim3 fill_grid(static_cast<unsigned>(max_tiles),
-                                 static_cast<unsigned>(Geometry::KVHeads),
-                                 static_cast<unsigned>(kGqaKvQuantGroups));
-            gqa_attention_prefill_fill_i8_page_kernel<Geometry, PackedV, RotateK, RotateV, PackedK, E8Lattice, E8Root, Metadata>
-                <<<fill_grid, kPageBlock, 0, stream>>>(
-                    static_cast<const __nv_bfloat16*>(k.data),
-                    static_cast<const __nv_bfloat16*>(v.data),
-                    static_cast<const std::int32_t*>(positions.data), metadata,
-                    static_cast<std::int8_t*>(cache_k.data),
-                    static_cast<std::uint8_t*>(cache_v.data),
-                    static_cast<__half*>(cache_k_scale.data),
-                    static_cast<__half*>(cache_v_scale.data), tokens);
-        } else {
-            constexpr int kFillWarps = kFillBlock / 32;
-            const std::int64_t fill_units =
-                static_cast<std::int64_t>(tokens) * Geometry::KVHeads * kGqaKvQuantGroups;
-            const int fill_grid =
-                static_cast<int>(div_up(fill_units, static_cast<std::int64_t>(kFillWarps)));
-            gqa_attention_prefill_fill_i8_kernel<Geometry, PackedV, RotateK, RotateV, PackedK, E8Lattice, E8Root, Metadata>
-                <<<fill_grid, kFillBlock, 0, stream>>>(
-                    static_cast<const __nv_bfloat16*>(k.data),
-                    static_cast<const __nv_bfloat16*>(v.data),
-                    static_cast<const std::int32_t*>(positions.data), metadata,
-                    static_cast<std::int8_t*>(cache_k.data),
-                    static_cast<std::uint8_t*>(cache_v.data),
-                    static_cast<__half*>(cache_k_scale.data),
-                    static_cast<__half*>(cache_v_scale.data), tokens);
-        }
-        };
-        if (cache.e8_root) {
-            launch_fill.template operator()<true, true, true, false, false, true>();
-        } else if (cache.e8_lattice) {
-            launch_fill.template operator()<true, true, true, true, true, false>();
-        } else if (cache.packed_k) {
-            launch_fill.template operator()<true, true, true, true, false, false>();
-        } else if (cache.packed_v) {
-            launch_fill.template operator()<true, true, true, false, false, false>();
-        } else {
-            launch_fill.template operator()<false, false, false, false, false, false>();
-        }
+        gqa_prefill_attention_i8<Geometry, CacheView, Metadata>(q, positions, scale, cache,
+                                                                metadata, out, stream);
     } else {
-        constexpr int kBlock           = Geometry::KVHeads == 4 ? 128 : 96;
-        constexpr int kFillVecElems    = 8;
-        const std::int64_t kv_elements = static_cast<std::int64_t>(tokens) * Geometry::KVHeads *
-                                         (kGqaPrefillHeadDim / kFillVecElems);
-        const int fill_grid =
-            static_cast<int>(div_up(kv_elements, static_cast<std::int64_t>(kBlock)));
-        gqa_attention_prefill_fill_bf16_kernel<Geometry, Metadata>
-            <<<fill_grid, kBlock, 0, stream>>>(static_cast<const __nv_bfloat16*>(k.data),
-                                               static_cast<const __nv_bfloat16*>(v.data),
-                                               static_cast<const std::int32_t*>(positions.data),
-                                               metadata, static_cast<__nv_bfloat16*>(cache_k.data),
-                                               static_cast<__nv_bfloat16*>(cache_v.data), tokens);
+        gqa_prefill_attention_bf16<Geometry, CacheView, Metadata>(q, positions, scale, cache,
+                                                                  metadata, out, stream);
+    }
+    // Compressed-KV formats store V rotated; un-rotate the output rows once
+    // after attention (plain bf16/int8 caches never set rotate_v).
+    if (cache.rotate_v) {
+        const auto tokens = static_cast<std::int32_t>(q.ne[2]);
+        gqa_kv_inverse_rotate_output_kernel<Geometry::QHeads>
+            <<<tokens * Geometry::QHeads * kGqaKvQuantGroups, 32, 0, stream>>>(
+                static_cast<__nv_bfloat16*>(out.data), tokens, tokens, 0, nullptr);
         CUDA_CHECK(cudaGetLastError());
     }
 }
@@ -154,12 +56,11 @@ void gqa_attention_prompt_attention_launch(const Tensor& q, const Tensor& positi
     const GqaPrefillDirectMetadata metadata{
         static_cast<const std::int32_t*>(cache.block_table.data)};
     if (q.ne[1] == Gqa27Geometry::QHeads) {
-        gqa_attention_prompt_attention_launch_for<Gqa27Geometry>(q, positions, scale, cache,
-                                                                 metadata, out, stream);
+        gqa_prefill_attention_route<Gqa27Geometry>(q, positions, scale, cache, metadata, out,
+                                                   stream);
         return;
     }
-    gqa_attention_prompt_attention_launch_for<Gqa35Geometry>(q, positions, scale, cache, metadata,
-                                                             out, stream);
+    gqa_prefill_attention_route<Gqa35Geometry>(q, positions, scale, cache, metadata, out, stream);
 }
 
 void gqa_kv_append_launch(const Tensor& k, const Tensor& v, const Tensor& positions,
@@ -167,10 +68,10 @@ void gqa_kv_append_launch(const Tensor& k, const Tensor& v, const Tensor& positi
     const GqaPrefillDirectMetadata metadata{
         static_cast<const std::int32_t*>(cache.block_table.data)};
     if (k.ne[1] == Gqa27Geometry::KVHeads) {
-        gqa_kv_append_launch_for<Gqa27Geometry>(k, v, positions, cache, metadata, stream);
+        gqa_prefill_append_route<Gqa27Geometry>(k, v, positions, cache, metadata, stream);
         return;
     }
-    gqa_kv_append_launch_for<Gqa35Geometry>(k, v, positions, cache, metadata, stream);
+    gqa_prefill_append_route<Gqa35Geometry>(k, v, positions, cache, metadata, stream);
 }
 
 void gqa_attention_prompt_launch(const Tensor& q, const Tensor& k, const Tensor& v,
@@ -186,14 +87,14 @@ void gqa_attention_prompt_launch(const Tensor& q, const Tensor& k, const Tensor&
             .table_stride = cache.block_tables.ne[0],
         };
         if (q.ne[1] == Gqa27Geometry::QHeads) {
-            gqa_kv_append_launch_for<Gqa27Geometry>(k, v, positions, cache, metadata, stream);
-            gqa_attention_prompt_attention_launch_for<Gqa27Geometry>(q, positions, scale, cache,
-                                                                     metadata, out, stream);
+            gqa_prefill_append_route<Gqa27Geometry>(k, v, positions, cache, metadata, stream);
+            gqa_prefill_attention_route<Gqa27Geometry>(q, positions, scale, cache, metadata, out,
+                                                       stream);
             return;
         }
-        gqa_kv_append_launch_for<Gqa35Geometry>(k, v, positions, cache, metadata, stream);
-        gqa_attention_prompt_attention_launch_for<Gqa35Geometry>(q, positions, scale, cache,
-                                                                 metadata, out, stream);
+        gqa_prefill_append_route<Gqa35Geometry>(k, v, positions, cache, metadata, stream);
+        gqa_prefill_attention_route<Gqa35Geometry>(q, positions, scale, cache, metadata, out,
+                                                   stream);
     };
     if (valid_columns.data == nullptr) {
         launch.template operator()<false>();

--- a/src/ops/launcher/gqa_attention_prefill_bf16.cu
+++ b/src/ops/launcher/gqa_attention_prefill_bf16.cu
@@ -1,0 +1,76 @@
+// ninfer::ops - BF16 prompt/prefill route. Split from the unified dispatcher so
+// this kernel family compiles in its own translation unit.
+#include "ops/launcher/gqa_attention.h"
+
+#include "ops/common/math.h"
+#include "ops/kernel/gqa_attention_prefill_bf16.cuh"
+#include "core/device.h" // CUDA_CHECK
+
+#include <cstdint>
+
+namespace ninfer::ops::detail {
+
+template <typename Geometry, typename CacheView, typename Metadata>
+void gqa_prefill_attention_bf16(const Tensor& q, const Tensor& positions, float scale,
+                                const CacheView& cache, Metadata metadata, Tensor& out,
+                                cudaStream_t stream) {
+    const Tensor& cache_k = cache.k_pages;
+    const Tensor& cache_v = cache.v_pages;
+    static const cudaError_t attr_bf16 =
+        cudaFuncSetAttribute(gqa_attention_prefill_bf16_kernel<Geometry, Metadata>,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize, kGqaPrefillSmemBytes);
+    CUDA_CHECK(attr_bf16);
+
+    const auto tokens = static_cast<std::int32_t>(q.ne[2]);
+    const dim3 attention_grid(static_cast<unsigned>(div_up(tokens, kGqaPrefillBr)),
+                              static_cast<unsigned>(Geometry::QHeads), 1u);
+    gqa_attention_prefill_bf16_kernel<Geometry, Metadata>
+        <<<attention_grid, kGqaPrefillThreads, kGqaPrefillSmemBytes, stream>>>(
+            static_cast<const __nv_bfloat16*>(q.data),
+            static_cast<const __nv_bfloat16*>(cache_k.data),
+            static_cast<const __nv_bfloat16*>(cache_v.data), metadata,
+            static_cast<const std::int32_t*>(positions.data), scale,
+            static_cast<__nv_bfloat16*>(out.data), tokens);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+template <typename Geometry, typename CacheView, typename Metadata>
+void gqa_prefill_append_bf16(const Tensor& k, const Tensor& v, const Tensor& positions,
+                             CacheView cache, Metadata metadata, cudaStream_t stream) {
+    const auto tokens = static_cast<std::int32_t>(k.ne[2]);
+    Tensor& cache_k   = cache.k_pages;
+    Tensor& cache_v   = cache.v_pages;
+    constexpr int kBlock           = Geometry::KVHeads == 4 ? 128 : 96;
+    constexpr int kFillVecElems    = 8;
+    const std::int64_t kv_elements = static_cast<std::int64_t>(tokens) * Geometry::KVHeads *
+                                     (kGqaPrefillHeadDim / kFillVecElems);
+    const int fill_grid =
+        static_cast<int>(div_up(kv_elements, static_cast<std::int64_t>(kBlock)));
+    gqa_attention_prefill_fill_bf16_kernel<Geometry, Metadata>
+        <<<fill_grid, kBlock, 0, stream>>>(static_cast<const __nv_bfloat16*>(k.data),
+                                           static_cast<const __nv_bfloat16*>(v.data),
+                                           static_cast<const std::int32_t*>(positions.data),
+                                           metadata, static_cast<__nv_bfloat16*>(cache_k.data),
+                                           static_cast<__nv_bfloat16*>(cache_v.data), tokens);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+#define NINFER_GQA_PREFILL_BF16_INSTANTIATE(GEOMETRY, CACHE_VIEW, METADATA)                         \
+    template void gqa_prefill_attention_bf16<GEOMETRY, CACHE_VIEW, METADATA>(                       \
+        const Tensor&, const Tensor&, float, const CACHE_VIEW&, METADATA, Tensor&, cudaStream_t);   \
+    template void gqa_prefill_append_bf16<GEOMETRY, CACHE_VIEW, METADATA>(                          \
+        const Tensor&, const Tensor&, const Tensor&, CACHE_VIEW, METADATA, cudaStream_t);
+
+NINFER_GQA_PREFILL_BF16_INSTANTIATE(Gqa27Geometry, PagedKVLayerView, GqaPrefillDirectMetadata)
+NINFER_GQA_PREFILL_BF16_INSTANTIATE(Gqa35Geometry, PagedKVLayerView, GqaPrefillDirectMetadata)
+NINFER_GQA_PREFILL_BF16_INSTANTIATE(Gqa27Geometry, PagedKVBatchLayerView,
+                                    GqaPrefillBatchMetadata<false>)
+NINFER_GQA_PREFILL_BF16_INSTANTIATE(Gqa27Geometry, PagedKVBatchLayerView,
+                                    GqaPrefillBatchMetadata<true>)
+NINFER_GQA_PREFILL_BF16_INSTANTIATE(Gqa35Geometry, PagedKVBatchLayerView,
+                                    GqaPrefillBatchMetadata<false>)
+NINFER_GQA_PREFILL_BF16_INSTANTIATE(Gqa35Geometry, PagedKVBatchLayerView,
+                                    GqaPrefillBatchMetadata<true>)
+#undef NINFER_GQA_PREFILL_BF16_INSTANTIATE
+
+} // namespace ninfer::ops::detail

--- a/src/ops/launcher/gqa_attention_prefill_i8.cu
+++ b/src/ops/launcher/gqa_attention_prefill_i8.cu
@@ -1,0 +1,134 @@
+// ninfer::ops - INT8 prompt/prefill route. Split from the unified dispatcher so
+// this kernel family compiles in its own translation unit. The compressed-KV
+// packing/codec variant is selected here from the cache view flags.
+#include "ops/launcher/gqa_attention.h"
+
+#include "ops/common/math.h"
+#include "ops/kernel/gqa_attention_prefill_i8.cuh"
+#include "core/device.h" // CUDA_CHECK
+
+#include <cstdint>
+
+namespace ninfer::ops::detail {
+
+template <typename Geometry, typename CacheView, typename Metadata>
+void gqa_prefill_attention_i8(const Tensor& q, const Tensor& positions, float scale,
+                              const CacheView& cache, Metadata metadata, Tensor& out,
+                              cudaStream_t stream) {
+    const Tensor& cache_k = cache.k_pages;
+    const Tensor& cache_v = cache.v_pages;
+    const auto tokens = static_cast<std::int32_t>(q.ne[2]);
+    const dim3 attention_grid(static_cast<unsigned>(div_up(tokens, kGqaPrefillI8Br)),
+                              static_cast<unsigned>(Geometry::QHeads), 1u);
+    const Tensor& cache_k_scale = cache.k_scale_pages;
+    const Tensor& cache_v_scale = cache.v_scale_pages;
+    const auto launch_i8 =
+        [&]<bool PackedV, bool RotateK, bool RotateV, bool PackedK, bool E8Root>() {
+        static const cudaError_t attr_i8 = cudaFuncSetAttribute(
+            gqa_attention_prefill_i8_kernel<Geometry, PackedV, RotateK, RotateV, PackedK, E8Root,
+                                            Metadata>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, kGqaPrefillI8SmemBytes);
+        CUDA_CHECK(attr_i8);
+        gqa_attention_prefill_i8_kernel<Geometry, PackedV, RotateK, RotateV, PackedK, E8Root,
+                                        Metadata>
+            <<<attention_grid, kGqaPrefillI8Threads, kGqaPrefillI8SmemBytes, stream>>>(
+                static_cast<const __nv_bfloat16*>(q.data),
+                static_cast<const std::int8_t*>(cache_k.data),
+                static_cast<const std::uint8_t*>(cache_v.data),
+                static_cast<const __half*>(cache_k_scale.data),
+                static_cast<const __half*>(cache_v_scale.data), metadata,
+                static_cast<const std::int32_t*>(positions.data), scale,
+                static_cast<__nv_bfloat16*>(out.data), tokens);
+    };
+    if (cache.e8_root) {
+        launch_i8.template operator()<true, true, true, false, true>();
+    } else if (cache.packed_k) {
+        launch_i8.template operator()<true, true, true, true, false>();
+    } else if (cache.packed_v) {
+        launch_i8.template operator()<true, true, true, false, false>();
+    } else {
+        launch_i8.template operator()<false, false, false, false, false>();
+    }
+    CUDA_CHECK(cudaGetLastError());
+}
+
+template <typename Geometry, typename CacheView, typename Metadata>
+void gqa_prefill_append_i8(const Tensor& k, const Tensor& v, const Tensor& positions,
+                           CacheView cache, Metadata metadata, cudaStream_t stream) {
+    const auto tokens = static_cast<std::int32_t>(k.ne[2]);
+    Tensor& cache_k   = cache.k_pages;
+    Tensor& cache_v   = cache.v_pages;
+    Tensor& cache_k_scale = cache.k_scale_pages;
+    Tensor& cache_v_scale = cache.v_scale_pages;
+    constexpr int kFillBlock = 256;
+    const auto launch_fill =
+        [&]<bool PackedV, bool RotateK, bool RotateV, bool PackedK, bool E8Lattice, bool E8Root>() {
+        if (tokens >= 32) {
+            constexpr int kPageBlock     = 256;
+            constexpr int kTokensPerTile = 8;
+            const int max_tiles =
+                static_cast<int>(div_up(tokens + kTokensPerTile, kTokensPerTile));
+            const dim3 fill_grid(static_cast<unsigned>(max_tiles),
+                                 static_cast<unsigned>(Geometry::KVHeads),
+                                 static_cast<unsigned>(kGqaKvQuantGroups));
+            gqa_attention_prefill_fill_i8_page_kernel<Geometry, PackedV, RotateK, RotateV, PackedK,
+                                                      E8Lattice, E8Root, Metadata>
+                <<<fill_grid, kPageBlock, 0, stream>>>(
+                    static_cast<const __nv_bfloat16*>(k.data),
+                    static_cast<const __nv_bfloat16*>(v.data),
+                    static_cast<const std::int32_t*>(positions.data), metadata,
+                    static_cast<std::int8_t*>(cache_k.data),
+                    static_cast<std::uint8_t*>(cache_v.data),
+                    static_cast<__half*>(cache_k_scale.data),
+                    static_cast<__half*>(cache_v_scale.data), tokens);
+        } else {
+            constexpr int kFillWarps = kFillBlock / 32;
+            const std::int64_t fill_units =
+                static_cast<std::int64_t>(tokens) * Geometry::KVHeads * kGqaKvQuantGroups;
+            const int fill_grid =
+                static_cast<int>(div_up(fill_units, static_cast<std::int64_t>(kFillWarps)));
+            gqa_attention_prefill_fill_i8_kernel<Geometry, PackedV, RotateK, RotateV, PackedK,
+                                                 E8Lattice, E8Root, Metadata>
+                <<<fill_grid, kFillBlock, 0, stream>>>(
+                    static_cast<const __nv_bfloat16*>(k.data),
+                    static_cast<const __nv_bfloat16*>(v.data),
+                    static_cast<const std::int32_t*>(positions.data), metadata,
+                    static_cast<std::int8_t*>(cache_k.data),
+                    static_cast<std::uint8_t*>(cache_v.data),
+                    static_cast<__half*>(cache_k_scale.data),
+                    static_cast<__half*>(cache_v_scale.data), tokens);
+        }
+    };
+    if (cache.e8_root) {
+        launch_fill.template operator()<true, true, true, false, false, true>();
+    } else if (cache.e8_lattice) {
+        launch_fill.template operator()<true, true, true, true, true, false>();
+    } else if (cache.packed_k) {
+        launch_fill.template operator()<true, true, true, true, false, false>();
+    } else if (cache.packed_v) {
+        launch_fill.template operator()<true, true, true, false, false, false>();
+    } else {
+        launch_fill.template operator()<false, false, false, false, false, false>();
+    }
+    CUDA_CHECK(cudaGetLastError());
+}
+
+#define NINFER_GQA_PREFILL_I8_INSTANTIATE(GEOMETRY, CACHE_VIEW, METADATA)                           \
+    template void gqa_prefill_attention_i8<GEOMETRY, CACHE_VIEW, METADATA>(                         \
+        const Tensor&, const Tensor&, float, const CACHE_VIEW&, METADATA, Tensor&, cudaStream_t);   \
+    template void gqa_prefill_append_i8<GEOMETRY, CACHE_VIEW, METADATA>(                           \
+        const Tensor&, const Tensor&, const Tensor&, CACHE_VIEW, METADATA, cudaStream_t);
+
+NINFER_GQA_PREFILL_I8_INSTANTIATE(Gqa27Geometry, PagedKVLayerView, GqaPrefillDirectMetadata)
+NINFER_GQA_PREFILL_I8_INSTANTIATE(Gqa35Geometry, PagedKVLayerView, GqaPrefillDirectMetadata)
+NINFER_GQA_PREFILL_I8_INSTANTIATE(Gqa27Geometry, PagedKVBatchLayerView,
+                                  GqaPrefillBatchMetadata<false>)
+NINFER_GQA_PREFILL_I8_INSTANTIATE(Gqa27Geometry, PagedKVBatchLayerView,
+                                  GqaPrefillBatchMetadata<true>)
+NINFER_GQA_PREFILL_I8_INSTANTIATE(Gqa35Geometry, PagedKVBatchLayerView,
+                                  GqaPrefillBatchMetadata<false>)
+NINFER_GQA_PREFILL_I8_INSTANTIATE(Gqa35Geometry, PagedKVBatchLayerView,
+                                  GqaPrefillBatchMetadata<true>)
+#undef NINFER_GQA_PREFILL_I8_INSTANTIATE
+
+} // namespace ninfer::ops::detail


### PR DESCRIPTION
Hey 👋 Thanks for this fork.

I started with this fork to work in a Windows environment. It is very useful!

I'm conducting some experiments to put a larger context into my single 5090, and the biggest problem was the slow build speed in the Windows CUDA toolkit. In my machine, it took almost 50 minutes, so I had to fix this first to iterate more. After the this change and a ninja wrapper, the build takes 15 minutes. It is still a long time, but it is better.

All this commits and below comment is written by AI (GLM-5.3)

----

The two unified GQA launcher TUs instantiated every dtype and geometry variant of every kernel family in single objects: gqa_attention_prefill.cu spent 1167s and gqa_attention_decode.cu 590s in cicc+ptxas alone (serial, sm_120a, CUDA 13.3), and MSBuild scheduled them back to back, dominating both cold and incremental engine builds.

Each dtype now compiles in its own translation unit (bf16, i8) behind a thin dispatcher that keeps the host split policy, route selection, and the split reducer. Public launcher and kernel contracts are unchanged; every route is an explicit instantiation of the same templates the unified dispatcher previously instantiated implicitly.