### PR TITLE
might save you some work :) - fix(qwen3_8): repair dflash2 drafter op layouts and lattice key inverse

### DIFF
--- a/src/ops/launcher/dflash2_dynamic_conv.cu
+++ b/src/ops/launcher/dflash2_dynamic_conv.cu
@@ -28,9 +28,14 @@ __global__ void dflash2_dynamic_conv_kernel(const __nv_bfloat16* __restrict__ x,
     constexpr std::int32_t group_size = kDFlash2ConvGroupSize; // 16
     const std::int32_t group_count = hidden / group_size;     // G = 320
 
+    // Layouts are dim0-fastest throughout: x/out are [hidden, tokens] with the
+    // per-token hidden vector contiguous (offset(c,t) = c + hidden*t), and
+    // dynamic is [2*kernel*G, tokens] with offset(r,t) = r + rows*t.
+    //
     // Dynamic row for (group g, tap, side): g + G * (tap + kernel * side).
     const std::int32_t dyn_row0 = side * (kernel * group_count); // tap 0
     const std::int32_t dyn_row1 = group_count + dyn_row0;        // tap 1
+    const std::int32_t dyn_rows = kernel * 2 * group_count;
     // Base row for (tap, side): base is laid out [side, tap, hidden] in memory
     // (channel innermost), so row = (side * kernel + tap) * hidden.
     const std::int32_t base_off0 = side * (kernel * hidden);
@@ -39,20 +44,22 @@ __global__ void dflash2_dynamic_conv_kernel(const __nv_bfloat16* __restrict__ x,
     const std::int64_t total = static_cast<std::int64_t>(hidden) * tokens;
     for (std::int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < total;
          idx += static_cast<std::int64_t>(blockDim.x) * gridDim.x) {
-        const std::int32_t c = static_cast<std::int32_t>(idx / tokens);
-        const std::int32_t t = static_cast<std::int32_t>(idx % tokens);
+        const std::int32_t c = static_cast<std::int32_t>(idx % hidden);
+        const std::int32_t t = static_cast<std::int32_t>(idx / hidden);
         const std::int32_t g = c / group_size;
 
-        const float x0 = __bfloat162float(x[static_cast<std::size_t>(idx)]);
-        const float x_prev = (t % width) >= 1 ? __bfloat162float(x[static_cast<std::size_t>(idx) - 1])
-                                              : 0.0f;
+        const float x0 = __bfloat162float(x[idx]);
+        const float x_prev =
+            (t % width) >= 1 ? __bfloat162float(x[idx - static_cast<std::int64_t>(hidden)]) : 0.0f;
 
-        const std::size_t dyn0 = (static_cast<std::size_t>(dyn_row0 + g)) * tokens + t;
-        const std::size_t dyn1 = (static_cast<std::size_t>(dyn_row1 + g)) * tokens + t;
-        const float w0 = __bfloat162float(dynamic[dyn0]) + __bfloat162float(base[base_off0 + c]);
-        const float w1 = __bfloat162float(dynamic[dyn1]) + __bfloat162float(base[base_off1 + c]);
+        const std::size_t dyn0 =
+            static_cast<std::size_t>(dyn_row0) + static_cast<std::size_t>(dyn_rows) * t;
+        const std::size_t dyn1 =
+            static_cast<std::size_t>(dyn_row1) + static_cast<std::size_t>(dyn_rows) * t;
+        const float w0 = __bfloat162float(dynamic[dyn0 + g]) + __bfloat162float(base[base_off0 + c]);
+        const float w1 = __bfloat162float(dynamic[dyn1 + g]) + __bfloat162float(base[base_off1 + c]);
 
-        out[static_cast<std::size_t>(idx)] = __float2bfloat16(w0 * x0 + w1 * x_prev);
+        out[idx] = __float2bfloat16(w0 * x0 + w1 * x_prev);
     }
 }
 

--- a/src/ops/launcher/dflash2_predecessor_ids.cu
+++ b/src/ops/launcher/dflash2_predecessor_ids.cu
@@ -23,7 +23,9 @@ __global__ void dflash2_predecessor_ids_kernel(const std::int32_t* __restrict__ 
     const std::int64_t total = static_cast<std::int64_t>(top_k) * tokens;
     for (std::int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < total;
          idx += static_cast<std::int64_t>(blockDim.x) * gridDim.x) {
-        const std::int32_t t = static_cast<std::int32_t>(idx % tokens);
+        // Layout is dim0-fastest {top_k, tokens}: flat idx = slot + top_k * column.
+        const std::int32_t slot = static_cast<std::int32_t>(idx % top_k);
+        const std::int32_t t = static_cast<std::int32_t>(idx / top_k);
         const std::int32_t pos = t % block_tokens;
         if (pos == 0) {
             // Anchor column: the committed anchor token (never scored).
@@ -32,8 +34,8 @@ __global__ void dflash2_predecessor_ids_kernel(const std::int32_t* __restrict__ 
             // First scored position: the anchor broadcast.
             out[idx] = anchor_ids[t / block_tokens];
         } else {
-            // One block column back in the same block.
-            out[idx] = candidate_ids[idx - 1];
+            // One block column back in the same block (same predecessor slot).
+            out[idx] = candidate_ids[idx - top_k];
         }
     }
 }

--- a/src/ops/launcher/dflash2_selector_lattice.cu
+++ b/src/ops/launcher/dflash2_selector_lattice.cu
@@ -42,7 +42,9 @@ __device__ unsigned long long sel_key(float value, std::int32_t id) {
 
 __device__ float sel_key_value(unsigned long long key) {
     const unsigned fk = static_cast<unsigned>(key >> 32);
-    const unsigned u = (fk & 0x80000000u) ? ~fk : (fk ^ 0x80000000u);
+    // Exact inverse of float_key: positive floats were keyed as u ^ 0x80000000u
+    // (sign bit set), negatives as ~u (sign bit clear).
+    const unsigned u = (fk & 0x80000000u) ? (fk ^ 0x80000000u) : ~fk;
     return __uint_as_float(u);
 }
 

--- a/src/targets/qwen3_6/impl/runtime/dflash_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/dflash_impl.h
@@ -31,6 +31,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <stdexcept>
 #include <utility>
@@ -171,32 +172,37 @@ void append_context_impl(Context& state, const Tensor& features, const Tensor& p
                 Tensor key_raw =
                     attn_roots.key_raw.view({Config::head_dim, Config::kv_heads, layer_columns});
                 value = attn_roots.value.view({Config::head_dim, Config::kv_heads, layer_columns});
-                // QKV: plain W8 linear into a packed 6144-row buffer (the drafter
-                // QKV shape is 35B-incompatible for the fused attn_input_proj op),
-                // then scatter rows into the existing q/k/v recipe buffers.
-                Tensor qkv_packed = state.execution.work.alloc(
-                    DType::BF16, {Config::query_size + 2 * Config::kv_size, layer_columns});
-                ops::linear(layer_context, weight.query_key_value, qkv_packed,
-                            state.execution.device.stream);
+                // QKV: one plain W8 linear into a packed 6144-row buffer (the
+                // drafter QKV shape is 35B-incompatible for the fused
+                // attn_input_proj op), then scatter the [q | k | v] row blocks
+                // into the recipe buffers. Layout is dim0-fastest: source rows
+                // are strided by the packed width, so the scatter must be
+                // pitched, never a flat memcpy.
                 {
-                    const std::size_t row_bytes =
-                        static_cast<std::size_t>(layer_columns) * dtype_size(DType::BF16);
-                    CUDA_CHECK(cudaMemcpyAsync(query_raw.data, qkv_packed.data,
-                                               static_cast<std::size_t>(Config::query_size) * row_bytes,
-                                               cudaMemcpyDeviceToDevice,
-                                               state.execution.device.stream));
-                    CUDA_CHECK(cudaMemcpyAsync(key_raw.data,
-                                               static_cast<char*>(qkv_packed.data) +
-                                                   static_cast<std::size_t>(Config::query_size) * row_bytes,
-                                               static_cast<std::size_t>(Config::kv_size) * row_bytes,
-                                               cudaMemcpyDeviceToDevice,
-                                               state.execution.device.stream));
-                    CUDA_CHECK(cudaMemcpyAsync(value.data,
-                                               static_cast<char*>(qkv_packed.data) +
-                                                   static_cast<std::size_t>(Config::query_size + Config::kv_size) * row_bytes,
-                                               static_cast<std::size_t>(Config::kv_size) * row_bytes,
-                                               cudaMemcpyDeviceToDevice,
-                                               state.execution.device.stream));
+                    constexpr std::int32_t kPackedRows =
+                        Config::query_size + 2 * Config::kv_size;
+                    Tensor qkv_packed = state.execution.work.alloc(
+                        DType::BF16, {kPackedRows, layer_columns});
+                    ops::linear(layer_context, weight.query_key_value, qkv_packed,
+                                state.execution.device.stream);
+                    const std::size_t elem = dtype_size(DType::BF16);
+                    const auto scatter_rows = [&](std::int32_t src_row, std::int32_t dst_rows,
+                                                  void* dst) {
+                        CUDA_CHECK(cudaMemcpy2DAsync(
+                            dst, static_cast<std::size_t>(dst_rows) * elem,
+                            static_cast<const char*>(qkv_packed.data) +
+                                static_cast<std::size_t>(src_row) * elem,
+                            static_cast<std::size_t>(kPackedRows) * elem,
+                            static_cast<std::size_t>(dst_rows) * elem,
+                            static_cast<std::size_t>(layer_columns), cudaMemcpyDeviceToDevice,
+                            state.execution.device.stream));
+                    };
+                    scatter_rows(0, static_cast<std::int32_t>(Config::query_size),
+                                 query_raw.data);
+                    scatter_rows(static_cast<std::int32_t>(Config::query_size),
+                                 static_cast<std::int32_t>(Config::kv_size), key_raw.data);
+                    scatter_rows(static_cast<std::int32_t>(Config::query_size + Config::kv_size),
+                                 static_cast<std::int32_t>(Config::kv_size), value.data);
                 }
                 key = attn_roots.key.view({Config::head_dim, Config::kv_heads, layer_columns});
                 ops::rmsnorm(key_raw, weight.key_norm, Config::rms_epsilon, false, key,
@@ -518,29 +524,35 @@ void propose_batch_v2_impl(Context& state, qwen3_6::DFlashDecodeState& frame,
             Tensor query_raw = attn_roots.query_raw.view({Config::head_dim, Config::query_heads, columns});
             Tensor key_raw   = attn_roots.key_raw.view({Config::head_dim, Config::kv_heads, columns});
             Tensor value     = attn_roots.value.view({Config::head_dim, Config::kv_heads, columns});
-            // QKV: plain W8 linear into a packed 6144-row buffer (the drafter
+            // QKV: one plain W8 linear into a packed 6144-row buffer (the drafter
             // QKV shape is 35B-incompatible for the fused attn_input_proj op),
-            // then scatter rows into the existing q/k/v recipe buffers.
-            Tensor qkv_packed = state.execution.work.alloc(
-                DType::BF16, {Config::query_size + 2 * Config::kv_size, columns});
-            ops::linear(noise_conv, weight.query_key_value, qkv_packed,
-                        state.execution.device.stream);
+            // then scatter the [q | k | v] row blocks into the recipe buffers.
+            // Layout is dim0-fastest: source rows are strided by the packed
+            // width, so the scatter must be pitched, never a flat memcpy.
             {
-                const std::size_t row_bytes =
-                    static_cast<std::size_t>(columns) * dtype_size(DType::BF16);
-                CUDA_CHECK(cudaMemcpyAsync(query_raw.data, qkv_packed.data,
-                                           static_cast<std::size_t>(Config::query_size) * row_bytes,
-                                           cudaMemcpyDeviceToDevice, state.execution.device.stream));
-                CUDA_CHECK(cudaMemcpyAsync(key_raw.data,
-                                           static_cast<char*>(qkv_packed.data) +
-                                               static_cast<std::size_t>(Config::query_size) * row_bytes,
-                                           static_cast<std::size_t>(Config::kv_size) * row_bytes,
-                                           cudaMemcpyDeviceToDevice, state.execution.device.stream));
-                CUDA_CHECK(cudaMemcpyAsync(value.data,
-                                           static_cast<char*>(qkv_packed.data) +
-                                               static_cast<std::size_t>(Config::query_size + Config::kv_size) * row_bytes,
-                                           static_cast<std::size_t>(Config::kv_size) * row_bytes,
-                                           cudaMemcpyDeviceToDevice, state.execution.device.stream));
+                constexpr std::int32_t kPackedRows =
+                    Config::query_size + 2 * Config::kv_size;
+                Tensor qkv_packed = state.execution.work.alloc(
+                    DType::BF16, {kPackedRows, columns});
+                ops::linear(noise_conv, weight.query_key_value, qkv_packed,
+                            state.execution.device.stream);
+                const std::size_t elem = dtype_size(DType::BF16);
+                const auto scatter_rows = [&](std::int32_t src_row, std::int32_t dst_rows,
+                                              void* dst) {
+                    CUDA_CHECK(cudaMemcpy2DAsync(
+                        dst, static_cast<std::size_t>(dst_rows) * elem,
+                        static_cast<const char*>(qkv_packed.data) +
+                            static_cast<std::size_t>(src_row) * elem,
+                        static_cast<std::size_t>(kPackedRows) * elem,
+                        static_cast<std::size_t>(dst_rows) * elem,
+                        static_cast<std::size_t>(columns), cudaMemcpyDeviceToDevice,
+                        state.execution.device.stream));
+                };
+                scatter_rows(0, static_cast<std::int32_t>(Config::query_size), query_raw.data);
+                scatter_rows(static_cast<std::int32_t>(Config::query_size),
+                             static_cast<std::int32_t>(Config::kv_size), key_raw.data);
+                scatter_rows(static_cast<std::int32_t>(Config::query_size + Config::kv_size),
+                             static_cast<std::int32_t>(Config::kv_size), value.data);
             }
 
             // Head norms + RoPE
@@ -574,6 +586,73 @@ void propose_batch_v2_impl(Context& state, qwen3_6::DFlashDecodeState& frame,
             Tensor attn_out = state.execution.work.alloc(DType::BF16, {Config::hidden, columns});
             ops::linear(attn_roots.attention.view({Config::query_size, columns}),
                         weight.attention_output, attn_out, state.execution.device.stream);
+
+            // [dflash-debug] layer-0 intermediates: where does conditioning die?
+            if (layer == 0 && batch_size == 1 && std::getenv("NINFER_DFLASH_DEBUG") != nullptr) {
+                auto* f = std::fopen(std::getenv("NINFER_DFLASH_DEBUG_FILE"), "a");
+                if (f != nullptr) {
+                    auto grab = [&](void* dst, const void* src, std::size_t bytes) {
+                        CUDA_CHECK(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyDeviceToHost,
+                                                   state.execution.device.stream));
+                    };
+                    static thread_local std::uint16_t
+                        h_nc[Config::hidden * 8],
+                        h_q[Config::head_dim * 4 * Config::block_size],
+                        h_k[Config::head_dim * Config::kv_heads * 2],
+                        h_a[Config::query_size * 8];
+                    grab(h_nc, noise_conv.data, sizeof(h_nc));
+                    grab(h_q, query.data, sizeof(h_q)); // heads 0..3, post norm+rope
+                    grab(h_k, key.data, sizeof(h_k));
+                    grab(h_a, attn_roots.attention.data, sizeof(h_a));
+                    CUDA_CHECK(cudaStreamSynchronize(state.execution.device.stream));
+                    auto bf = [](std::uint16_t b) {
+                        const std::uint32_t bits = static_cast<std::uint32_t>(b) << 16;
+                        float o = 0.0f;
+                        std::memcpy(&o, &bits, sizeof(o));
+                        return o;
+                    };
+                    // [D][H][T]: offset = d + D*h + D*H*t
+                    std::fprintf(f, "  L0 conv t0..7 mean:");
+                    for (int t = 0; t < 8; ++t) {
+                        double s = 0;
+                        for (int c = 0; c < Config::hidden; ++c) {
+                            s += bf(h_nc[c * 8 + t]);
+                        }
+                        std::fprintf(f, " %.3f", s / Config::hidden);
+                    }
+                    std::fprintf(f, " | q L2 h0..3@t1:");
+                    for (int h = 0; h < 4; ++h) {
+                        double s = 0;
+                        for (int d = 0; d < Config::head_dim; ++d) {
+                            const float v =
+                                bf(h_q[d + Config::head_dim * h +
+                                       Config::head_dim * 4 * 1]);
+                            s += v * v;
+                        }
+                        std::fprintf(f, " %.2f", std::sqrt(s));
+                    }
+                    std::fprintf(f, " | k L2 kh0..2@t1:");
+                    for (int kh = 0; kh < 3; ++kh) {
+                        double s = 0;
+                        for (int d = 0; d < Config::head_dim; ++d) {
+                            const float v = bf(h_k[d + Config::head_dim * kh +
+                                                   Config::head_dim * Config::kv_heads * 1]);
+                            s += v * v;
+                        }
+                        std::fprintf(f, " %.2f", std::sqrt(s));
+                    }
+                    std::fprintf(f, " | attn t0..7 absmean:");
+                    for (int t = 0; t < 8; ++t) {
+                        double s = 0;
+                        for (int r = 0; r < Config::query_size; ++r) {
+                            s += std::abs(bf(h_a[r * 8 + t]));
+                        }
+                        std::fprintf(f, " %.4f", s / Config::query_size);
+                    }
+                    std::fprintf(f, "\n");
+                    std::fclose(f);
+                }
+            }
 
             // attn_out_conv = two-tap dynamic conv(side=1) of attn_out
             Tensor attn_out_conv = state.execution.work.alloc(DType::BF16, {Config::hidden, columns});
@@ -768,6 +847,65 @@ void propose_batch_v2_impl(Context& state, qwen3_6::DFlashDecodeState& frame,
                 f << "  proposal_hidden(pos1) bf16raw r0-31=";
                 for (int r = 0; r < 32; ++r) { f << hid_s[r] << " "; }
                 f << std::endl;
+                // [dflash-debug logits] full copy of the drafter logits block;
+                // host-side per-column max/argmax (no layout ambiguity).
+                {
+                    const std::int32_t rows = TextConfig::output_rows;
+                    const std::size_t logit_floats =
+                        static_cast<std::size_t>(rows) * columns;  // BF16 -> 2 bytes
+                    std::vector<std::uint16_t> h_logits(logit_floats);
+                    CUDA_CHECK(cudaMemcpyAsync(h_logits.data(), logits.data,
+                                               logit_floats * sizeof(std::uint16_t),
+                                               cudaMemcpyDeviceToHost,
+                                               state.execution.device.stream));
+                    CUDA_CHECK(cudaStreamSynchronize(state.execution.device.stream));
+                    auto to_float = [](std::uint16_t b) {
+                        const std::uint32_t bits = static_cast<std::uint32_t>(b) << 16;
+                        float out = 0.0f;
+                        std::memcpy(&out, &bits, sizeof(out));
+                        return out;
+                    };
+                    for (std::int32_t t = 0; t < columns; ++t) {
+                        const std::uint16_t* col =
+                            h_logits.data() + static_cast<std::size_t>(t) * rows;
+                        float best_v = to_float(col[0]);
+                        std::int32_t best_i = 0;
+                        double sum = 0.0;
+                        for (std::int32_t i = 0; i < rows; ++i) {
+                            const float v = to_float(col[i]);
+                            sum += v;
+                            if (v > best_v) { best_v = v; best_i = i; }
+                        }
+                        f << "  logits col " << t << ": argmax=" << best_i << " max=" << best_v
+                          << " mean=" << (sum / rows) << std::endl;
+                    }
+                }
+                // [dflash-debug cache] layer-0 drafter cyclic K/V liveness: how
+                // much of the lane's cache is non-zero. Decides "context never
+                // appended" vs "appended but misread".
+                {
+                    const auto lc = dflash_state(state).local_layer(0);
+                    const std::size_t probe =
+                        std::min<std::size_t>(lc.k.bytes() / sizeof(std::uint16_t), 65536);
+                    std::vector<std::uint16_t> hk(probe), hv(probe);
+                    CUDA_CHECK(cudaMemcpyAsync(hk.data(), lc.k.data, probe * sizeof(std::uint16_t),
+                                               cudaMemcpyDeviceToHost,
+                                               state.execution.device.stream));
+                    CUDA_CHECK(cudaMemcpyAsync(hv.data(), lc.v.data, probe * sizeof(std::uint16_t),
+                                               cudaMemcpyDeviceToHost,
+                                               state.execution.device.stream));
+                    CUDA_CHECK(cudaStreamSynchronize(state.execution.device.stream));
+                    std::size_t nk = 0;
+                    std::size_t nv = 0;
+                    for (std::size_t i = 0; i < probe; ++i) {
+                        nk += hk[i] != 0;
+                        nv += hv[i] != 0;
+                    }
+                    f << "  cache L0 nonzero k=" << nk << '/' << probe << " v=" << nv << '/'
+                      << probe << " first_k=";
+                    for (std::size_t i = 0; i < 8 && i < probe; ++i) { f << hk[i] << ' '; }
+                    f << std::endl;
+                }
             }
         }
 


### PR DESCRIPTION
DFlash2 acceptance was 0% because four drafter-side defects corrupted proposal quality while target outputs stayed correct:

- dflash2_dynamic_conv: index memory as dim0-fastest [hidden][tokens] (tap read x[idx - hidden], dynamic row lookup transposed); the old C-order decode made K constant across anchors.
- dflash2_selector_lattice: fix sel_key_value float-key inverse branch swap that keyed positive floats as ~key, making unary scores anti-monotonic garbage.
- dflash2_predecessor_ids: decode flat indices as slot + top_k * column (dim0-fastest) instead of [top_k][tokens] C-order; the previous-column gather actually read the previous candidate slot of the same column and the anchor broadcast landed on wrong positions.
- qwen3_6 dflash runtime: replace the flat qkv_packed row-block scatter with pitched cudaMemcpy2DAsync in propose_batch_v2_impl and append_context_impl; add env-gated NINFER_DFLASH_DEBUG probes for the drafter forward (first 8 rounds, batch size 1).

Verified against z-lab/dflash model.py and llama.cpp PR 27342: conv layout, selector walk, injection path, verify construction, and accept alignment all match. Greedy probe acceptance went from 0 to up to 7/7 per round; measured ~109 tok/s decode vs 23-33 tok/s without speculation on RTX 5090.