### PR TITLE
test(serve): align Windows schema tests with current contracts

### DIFF
--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -238,11 +238,8 @@ int test_reasoning_effort() {
 
     Json conflict               = low;
     conflict["enable_thinking"] = false;
-    const GenerationRequest conflicting_request =
-        parse_chat_completion_request(conflict, default_limits());
     failures += check(api_code([&] {
-                          (void)resolve_prompt_semantics(conflicting_request, default_server(),
-                                                         effort_capabilities());
+                          (void)parse_chat_completion_request(conflict, default_limits());
                       }) == "conflicting_template_option",
                       "conflicting enable_thinking and reasoning_effort were accepted");
 
@@ -905,7 +902,7 @@ int test_props_stub() {
     options.max_context                = 16384;
     options.default_max_tokens         = 4096;
     options.enable_vision              = true;
-    options.speculative.backend        = SpeculativeBackend::Mtp;
+    options.speculative.backend        = ninfer::SpeculativeBackend::Mtp;
     options.sampling_overrides.temperature = 1.0F;
     options.sampling_overrides.top_k       = 20;
 
@@ -913,8 +910,9 @@ int test_props_stub() {
     failures += check(props.at("role") == "model", "props role is model");
     failures += check(props.at("modalities").at("vision") == true, "props vision follows --vision");
     failures += check(props.at("modalities").at("audio") == false, "props audio off");
+    failures += check(props.at("default_generation_settings").at("n_ctx") == 16384,
+                      "props n_ctx from --max-context");
     const Json params = props.at("default_generation_settings").at("params");
-    failures += check(params.at("n_ctx") == 16384, "props n_ctx from --max-context");
     failures += check(params.at("n_predict") == 4096, "props n_predict from default max tokens");
     failures += check(params.at("temperature") == 1.0, "props temperature override reported");
     failures += check(params.at("top_k") == 20, "props top_k override reported");


### PR DESCRIPTION
# test(serve): align Windows schema tests with current contracts

## Problem

`ninfer_openai_schema_test` no longer matched three contracts already implemented by the Windows
server branch:

- MSVC requires the speculative backend enum to be qualified with its `ninfer` namespace;
- conflicting `enable_thinking=false` and `reasoning_effort=low` is rejected by the request parser,
  before prompt semantics are resolved; and
- `/props` exposes `n_ctx` directly under `default_generation_settings`, not under `params`.

The stale assertions caused a compile failure followed by a failing schema test even though the
server behavior was correct.

## Design and affected behavior

Update only `tests/test_openai_schema.cpp` to assert the current parser and `/props` contracts and
to use the fully qualified enum. No serving, inference, model, sampling, CUDA, or public protocol
behavior changes.

## Verification

Windows 11, MSVC 19.39 / Visual Studio Build Tools 2022, CUDA 13.1, RTX 5090:

```text
cmake --build C:\src\ninfer-build -j --config Release --target ninfer_openai_schema_test
```

Result: target built successfully.

```text
ctest --test-dir C:\src\ninfer-build -C Release -R "^ninfer_openai_schema_test$" --output-on-failure
```

Result: `1/1` passed.

```text
git diff --check b686696eebd43b72f58239740ae002fad6afaf5e..7ec96c7e50988e3e053d959640b46ded32700944
```

Result: passed with no output.

The full suite was not rerun because this is a test-only correction in one translation unit and
does not change production code.

## AI disclosure

The implementation was produced with OpenAI GPT-5.6 Sol (Codex, xhigh reasoning). I reviewed the
complete diff, verified each assertion against the current implementation, and ran the focused
Windows build and test above.
