### PR TITLE
feat: port qwen3.8-27b nvfp4full support (target + converter) onto latest master

### DIFF
--- a/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
+++ b/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
@@ -33,6 +33,7 @@ enum class WeightsProfile : std::uint8_t {
     Qwen38GroupwiseInt,
     Qwen36Nvfp4,
     Qwen38Nvfp4,
+    Qwen38Nvfp4Full,
 };
 
 using Frontend        = qwen3_6::Frontend;

--- a/src/targets/qwen3_6_27b/impl/load/bindings.cpp
+++ b/src/targets/qwen3_6_27b/impl/load/bindings.cpp
@@ -38,6 +38,7 @@ NumericFormat endpoint_format(WeightsProfile weights_profile) {
         return NumericFormat::Q6G64_F16S;
     case WeightsProfile::Qwen38GroupwiseInt:
     case WeightsProfile::Qwen36Nvfp4:
+    case WeightsProfile::Qwen38Nvfp4Full:
         return NumericFormat::W8G32_F16S;
     case WeightsProfile::Qwen38Nvfp4:
         return NumericFormat::FP8_E4M3FN_ROW_BF16S;
@@ -389,6 +390,76 @@ void bind_qwen38_nvfp4_text_layers(artifact::Binder& binder, BindingPlan& out) {
     }
 }
 
+// The fuller Qwen3.8 NVFP4 allocation: the Qwen3.6 NVFP4 exception pattern with
+// this target's fused GDN control parent.
+void bind_qwen38_nvfp4full_text_layers(artifact::Binder& binder, BindingPlan& out) {
+    for (std::size_t layer = 0; layer < kTextLayers; ++layer) {
+        TextLayerPlan& target    = out.text_layers[layer];
+        const std::string prefix = "text/layers/" + std::to_string(layer) + "/";
+        target.input_norm        = artifact::bind_device_tensor(binder, prefix + "input_norm",
+                                                                NumericFormat::BF16, {5120});
+        target.is_full_attention = is_full_layer(layer);
+        if (target.is_full_attention) {
+            WeightPlan input;
+            if (is_early_attention_input(layer)) {
+                input = bind_weight(binder, prefix + "attention/query_key_gate_value",
+                                    NumericFormat::BF16, {14336, 5120});
+            } else {
+                input = bind_nvfp4_weight(
+                    binder, prefix + "attention/query_key_gate_value", 14336, 5120,
+                    prefix + "attention/input_projection/input_scale_divisor");
+            }
+            target.attention.projection =
+                FusedAttentionProjectionPlan{.query_key_gate_value = input};
+            target.attention.query_norm = artifact::bind_device_tensor(
+                binder, prefix + "attention/query_norm", NumericFormat::BF16, {256});
+            target.attention.key_norm = artifact::bind_device_tensor(
+                binder, prefix + "attention/key_norm", NumericFormat::BF16, {256});
+            if (is_bf16_attention_output(layer)) {
+                target.attention.output = bind_weight(binder, prefix + "attention/output",
+                                                      NumericFormat::BF16, {5120, 6144});
+            } else {
+                target.attention.output =
+                    bind_nvfp4_weight(binder, prefix + "attention/output", 5120, 6144,
+                                      prefix + "attention/output_projection/input_scale_divisor");
+            }
+        } else {
+            target.gdn.a_log       = artifact::bind_device_tensor(binder, prefix + "gdn/a_log",
+                                                                  NumericFormat::FP32, {48});
+            target.gdn.dt_bias     = artifact::bind_device_tensor(binder, prefix + "gdn/dt_bias",
+                                                                  NumericFormat::FP32, {48});
+            target.gdn.convolution = artifact::bind_device_tensor(
+                binder, prefix + "gdn/convolution", NumericFormat::BF16, {4, 10240});
+            target.gdn.control_projection = FusedGdnControlProjectionPlan{
+                .a_b_projection = bind_weight(binder, prefix + "gdn/a_b_projection",
+                                              NumericFormat::BF16, {96, 5120}),
+            };
+            target.gdn.input_projection = FusedGdnInputProjectionPlan{
+                .query_key_value_z =
+                    bind_nvfp4_weight(binder, prefix + "gdn/query_key_value_z", 16384, 5120,
+                                      prefix + "gdn/input_projection/input_scale_divisor"),
+            };
+            target.gdn.norm = artifact::bind_device_tensor(binder, prefix + "gdn/norm",
+                                                           NumericFormat::BF16, {128});
+            if (is_bf16_gdn_output(layer)) {
+                target.gdn.output =
+                    bind_weight(binder, prefix + "gdn/output", NumericFormat::BF16, {5120, 6144});
+            } else {
+                target.gdn.output =
+                    bind_nvfp4_weight(binder, prefix + "gdn/output", 5120, 6144,
+                                      prefix + "gdn/output_projection/input_scale_divisor");
+            }
+        }
+        target.post_attention_norm = artifact::bind_device_tensor(
+            binder, prefix + "post_attention_norm", NumericFormat::BF16, {5120});
+        target.mlp.gate_up =
+            bind_nvfp4_weight(binder, prefix + "mlp/gate_up", 34816, 5120,
+                              prefix + "mlp/gate_up_projection/input_scale_divisor");
+        target.mlp.down = bind_nvfp4_weight(binder, prefix + "mlp/down", 5120, 17408,
+                                            prefix + "mlp/down_projection/input_scale_divisor");
+    }
+}
+
 void validate_draft_ids(const artifact::Binder& binder, artifact::ObjectHandle handle) {
     constexpr std::size_t kDraftVocab     = 131072;
     constexpr std::size_t kTokenizerVocab = 248077;
@@ -430,6 +501,9 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
         break;
     case WeightsProfile::Qwen38Nvfp4:
         bind_qwen38_nvfp4_text_layers(binder, out);
+        break;
+    case WeightsProfile::Qwen38Nvfp4Full:
+        bind_qwen38_nvfp4full_text_layers(binder, out);
         break;
     default:
         throw std::invalid_argument("qwen3_6_27b: invalid weights profile");

--- a/src/targets/qwen3_6_27b/impl/package.cpp
+++ b/src/targets/qwen3_6_27b/impl/package.cpp
@@ -95,6 +95,9 @@ Package::WeightsProfile Package::resolve_weights(const artifact::ArtifactIdentit
     if (identity.model_id == qwen3_8_model_id && identity.weights_id == "nvfp4") {
         return WeightsProfile::Qwen38Nvfp4;
     }
+    if (identity.model_id == qwen3_8_model_id && identity.weights_id == "nvfp4full") {
+        return WeightsProfile::Qwen38Nvfp4Full;
+    }
     throw std::runtime_error("artifact identity '" + identity.model_id + "/" + identity.weights_id +
                              "' is not supported by target '" + std::string(target_key) + "'");
 }

--- a/src/targets/qwen3_6_27b/impl/variant.cpp
+++ b/src/targets/qwen3_6_27b/impl/variant.cpp
@@ -347,6 +347,7 @@ std::size_t Variant::attention_projection_workspace_capacity_bytes(WeightsProfil
     case WeightsProfile::Qwen38GroupwiseInt:
         return 0;
     case WeightsProfile::Qwen36Nvfp4:
+    case WeightsProfile::Qwen38Nvfp4Full:
         return ops::attn_input_proj_workspace_capacity_bytes(
             QType::NVFP4, 14336, TextConfig::hidden, kNvfp4TextPolicy, first, last);
     case WeightsProfile::Qwen38Nvfp4:
@@ -366,6 +367,7 @@ std::size_t Variant::attention_output_projection_workspace_capacity_bytes(
                                                         TextConfig::query_size,
                                                         ops::LinearPolicy::A16Only, first, last);
     case WeightsProfile::Qwen36Nvfp4:
+    case WeightsProfile::Qwen38Nvfp4Full:
         return ops::linear_add_workspace_capacity_bytes(QType::NVFP4, TextConfig::hidden,
                                                         TextConfig::query_size, kNvfp4TextPolicy,
                                                         first, last);
@@ -387,6 +389,7 @@ std::size_t Variant::gdn_input_projection_workspace_capacity_bytes(WeightsProfil
     case WeightsProfile::Qwen38GroupwiseInt:
         return 0;
     case WeightsProfile::Qwen36Nvfp4:
+    case WeightsProfile::Qwen38Nvfp4Full:
         return ops::gdn_input_proj_workspace_capacity_bytes(QType::NVFP4, 16384, TextConfig::hidden,
                                                             kNvfp4TextPolicy, first, last);
     case WeightsProfile::Qwen38Nvfp4:
@@ -408,6 +411,7 @@ std::size_t Variant::gdn_input_projection_snapshot_workspace_capacity_bytes(
                             TextConfig::key_dim, TextConfig::key_dim, TextConfig::value_dim,
                             batch_size, first, last));
     case WeightsProfile::Qwen36Nvfp4:
+    case WeightsProfile::Qwen38Nvfp4Full:
         return std::max(kMinimumLeafWorkspaceBytes,
                         ops::gdn_input_proj_conv_snapshot_workspace_capacity_bytes(
                             QType::NVFP4, 16384, TextConfig::hidden, kNvfp4TextPolicy, batch_size,
@@ -433,6 +437,7 @@ std::size_t Variant::gdn_input_projection_record_workspace_capacity_bytes(
                             TextConfig::key_dim, TextConfig::key_dim, TextConfig::value_dim,
                             batch_size, first, last));
     case WeightsProfile::Qwen36Nvfp4:
+    case WeightsProfile::Qwen38Nvfp4Full:
         return std::max(kMinimumLeafWorkspaceBytes,
                         ops::gdn_input_proj_conv_record_workspace_capacity_bytes(
                             QType::NVFP4, 16384, TextConfig::hidden, kNvfp4TextPolicy, batch_size,
@@ -458,6 +463,7 @@ std::size_t Variant::gdn_output_projection_workspace_capacity_bytes(WeightsProfi
                                                         TextConfig::value_dim,
                                                         ops::LinearPolicy::A16Only, first, last);
     case WeightsProfile::Qwen36Nvfp4:
+    case WeightsProfile::Qwen38Nvfp4Full:
         return ops::linear_add_workspace_capacity_bytes(
             QType::NVFP4, TextConfig::hidden, TextConfig::value_dim, kNvfp4TextPolicy, first, last);
     case WeightsProfile::Qwen38Nvfp4:
@@ -484,6 +490,7 @@ std::size_t Variant::post_mixer_workspace_capacity_bytes(WeightsProfile weights_
         return post_mixer_workspace_bytes(QType::Q4G64_F16S, QType::Q5G64_F16S,
                                           ops::LinearPolicy::A16Only, first, last);
     case WeightsProfile::Qwen36Nvfp4:
+    case WeightsProfile::Qwen38Nvfp4Full:
         return post_mixer_workspace_bytes(QType::NVFP4, QType::NVFP4, kNvfp4TextPolicy, first,
                                           last);
     case WeightsProfile::Qwen38Nvfp4: {

--- a/tools/convert/qwen3_8_27b/calibrate_nvfp4full.py
+++ b/tools/convert/qwen3_8_27b/calibrate_nvfp4full.py
@@ -1,0 +1,508 @@
+"""Calibrate NVFP4 site input divisors (d_x) for the fuller Qwen3.8-27B artifact.
+
+The BF16 checkpoint does not fit in device memory beside a resident model, so
+this tool streams one decoder layer at a time from the memory-mapped
+safetensors shards: a pre-forward hook materializes the layer's parameters on
+the GPU, the model's own forward evaluates it, and a post-forward hook evicts
+it. Only the token embedding stays resident. Every hooked site records the
+maximum absolute represented BF16 activation over the complete fixed corpus:
+
+    d_x = binary32(2688 / amax_site)        # 2688 = 6 * 448
+
+matching the A4 block-scale orientation ``s_x = E4M3FN(d_x * max_abs(block)/6)``.
+Sites whose weights come from the quantized source keep their stored divisor
+words; this tool measures only locally quantized sites, and additionally
+reports the same statistic for unsloth-owned MLP sites as a derivation check.
+
+Canonical invocation::
+
+    python3 -m tools.convert.qwen3_8_27b.calibrate_nvfp4full \
+      --model /path/to/Qwen3.8-27B \
+      --quantized-model /path/to/Qwen3.8-27B-NVFP4 \
+      --out out/qwen3_8_27b_nvfp4full_calibration.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import time
+from typing import Sequence
+
+import torch
+from safetensors import safe_open
+from transformers import AutoConfig, AutoTokenizer
+
+from tools.convert.common.safetensors import ShardReader
+
+
+FULL_RANGE = 2688.0
+FULL_ATTENTION_LAYERS = tuple(range(3, 64, 4))
+EARLY_ATTENTION_INPUT_LAYERS = (3, 7, 11, 15, 19, 23)
+BF16_ATTENTION_OUTPUT_LAYERS = (3, 7)
+BF16_GDN_OUTPUT_LAYERS = (4,)
+NVFP4_MLP_LAYERS_FROM_SOURCE = tuple(range(56))
+
+# Fixed calibration corpus. The documents are committed with the tool so the
+# calibration is deterministic; they cover prose, technical writing, source
+# code, and numeric tables.
+_CALIBRATION_DOCUMENTS = (
+    """The history of numerical weather prediction begins with Lewis Fry Richardson's 1922
+attempt to compute atmospheric pressure changes by hand. His forecast, produced by a room
+of human calculators working in shifts, took six weeks to advance the atmosphere by six
+hours and was wildly inaccurate. Yet the method he described - dividing the atmosphere into
+a grid of cells and applying the equations of fluid dynamics to each cell - is precisely
+what every modern forecast model does. The difference is that where Richardson needed
+weeks of human labor, a contemporary supercomputer performs the same arithmetic in a few
+seconds, on a grid a hundred times finer, and assimilates observations from satellites,
+aircraft, ocean buoys, and ground stations to initialize the computation. The forecasting
+problem is now less about raw computation than about representing small-scale physics:
+clouds, turbulence, and convection that fall below the grid resolution.""",
+    """Gradient-based optimization underlies nearly all of modern machine learning. Given a
+differentiable loss function L parameterized by weights w, training iterates w <- w - eta
+* grad L(w), where eta is the learning rate. Stochastic gradient descent estimates the
+gradient from minibatches; momentum accumulates a velocity v <- mu * v - eta * grad to
+damp oscillations across ill-conditioned valleys; and adaptive methods such as Adam
+maintain per-parameter running estimates of the first and second moments, rescaling the
+step by an estimate of the gradient's magnitude. Careful initialization matters: drawing
+weights from a distribution whose variance matches the fan-in and fan-out of each layer
+keeps activation magnitudes stable as signals propagate forward and gradients propagate
+backward. Normalization layers - batch norm, layer norm, RMSNorm - remove mean and scale
+drift, allowing higher learning rates. Learning-rate schedules decay eta over training:
+warmup ramps it up over the first few thousand steps, cosine schedules anneal it toward
+zero, and step schedules divide it by a constant at fixed milestones. Regularization by
+weight decay, dropout, and data augmentation counteracts overfitting.""",
+    """def build_frequency_table(samples: list[int], size: int) -> list[float]:
+    counts = [0] * size
+    for value in samples:
+        if not 0 <= value < size:
+            raise ValueError(f"sample out of range: {value}")
+        counts[value] += 1
+    total = sum(counts)
+    if total == 0:
+        return [0.0] * size
+    return [count / total for count in counts]
+
+def entropy(table: list[float]) -> float:
+    from math import log2
+    return -sum(p * log2(p) for p in table if p > 0.0)
+
+def rolling_checksum(data: bytes, window: int = 32, modulus: int = 16777619) -> int:
+    if window <= 0:
+        raise ValueError("window must be positive")
+    digest = 0
+    for i, byte in enumerate(data):
+        digest = (digest * 31 + byte) % modulus
+        if i >= window:
+            digest = (digest - data[i - window] * pow(31, window, modulus)) % modulus
+    return digest
+
+class RingBuffer:
+    def __init__(self, capacity: int) -> None:
+        self.capacity = capacity
+        self.items: list[float] = []
+        self.head = 0
+
+    def push(self, value: float) -> float | None:
+        evicted = None
+        if len(self.items) == self.capacity:
+            evicted = self.items[self.head]
+            self.items[self.head] = value
+            self.head = (self.head + 1) % self.capacity
+        else:
+            self.items.append(value)
+        return evicted""",
+    """Quarterly report extract, all figures in thousands of dollars unless noted.
+Revenue: Q1 4,812; Q2 5,377; Q3 5,940; Q4 6,512; full year 22,641, up 18.4 percent
+year over year. Cost of revenue: Q1 2,105; Q2 2,318; Q3 2,504; Q4 2,691. Gross margin
+improved from 56.2 percent in Q1 to 58.7 percent in Q4. Operating expenses: research and
+development 6,204, sales and marketing 4,481, general and administrative 1,902. Operating
+income 2,363 for the year, margin 10.4 percent. Net income 1,977 after interest expense
+of 214 and tax provision of 172 at an effective rate of 9.6 percent. Cash and equivalents
+11,340 at year end; inventory 2,905; accounts receivable 3,661 with days sales
+outstanding of 51. Capital expenditure 1,208, of which 744 related to compute capacity.
+Headcount ended at 612, up from 545, of which 289 in engineering. Contracted backlog
+stood at 9,880 with average duration of 2.3 years.""",
+    """Le vent se levait sur la plaine de Beauce balayant les champs de blé presque mûrs.
+Les paysans avaient fini la moisson dans le voisinage et les meules dorées attendaient
+les chariots. Au loin, on apercevait la flèche de la cathédrale, grise sur le ciel
+encore clair, tandis que des nuages épais montaient à l'horizon du côté de la forêt.
+La chaleur de la journée s'attardait dans l'air immobile du soir. On entendait
+seulement le froissement des feuilles sèches et, de temps en temps, l'aboiement d'un
+chien dans quelque ferme éloignée. Elle marcha longtemps sur le chemin creux entre les
+haies, ne pensant à rien, regardant la terre de Beauce s'endormir lentement dans la
+lumière déclinante. Il lui semblait que cette plaine interminable portait tous les
+travaux et toutes les saisons de sa vie, et que chaque sillon connaissait son nom.""",
+    """一九四三年秋，昆明的雨季来得比往年早。联大的教室屋顶是铁皮的，雨点打上去，
+声音大得讲课的人都听不见自己说话。教授停下来，学生们便合上笔记，听雨。有人
+后来回忆说，那几年的知识有一半是在雨声里学的。物价一日三涨，教授们在实验室
+外面种菜，在中学兼课，把藏书一册一册地卖出去。可是图书馆晚上依然坐满了人，
+一盏油灯下面常常是两个人。物理系的仪器用完了就拆，拆了又装。跑警报的日子，
+师生们在郊外的山沟里继续讨论功课，有人带着论文字典，有人带着未完成的实验
+记录。那些年在昆明写成的论文，后来散落在世界各地，但其中许多的初稿，是在
+铁皮屋顶下、油灯旁边、山沟里的石板上完成的。""",
+    """{
+  "session": {"id": "a4f7c2e1", "started": "2026-04-03T09:14:22Z", "region": "eu-west-1"},
+  "customer": {"tier": "enterprise", "seats": 1240, "renewal": "2027-01-15"},
+  "usage": {
+    "inference": {"requests": 8421937, "tokens_in": 1120394221, "tokens_out": 402118336},
+    "training": {"jobs": 217, "gpu_hours": 18432.5, "checkpoint_gb": 91.3}
+  },
+  "incidents": [
+    {"id": "INC-2201", "severity": 2, "started": "2026-03-28T21:04:11Z",
+     "duration_minutes": 43, "affected": ["inference", "dashboard"],
+     "cause": "upstream capacity provider failure", "resolved": true},
+    {"id": "INC-2207", "severity": 3, "started": "2026-04-01T02:33:57Z",
+     "duration_minutes": 11, "affected": ["batch-ingest"], "resolved": true}
+  ],
+  "capacity": {"gpu_allocated": 512, "gpu_used_peak": 489, "queue_depth_p99": 74}
+}""",
+    """El camión arrancó al amanecer y tomó la carretera de tierra que subía hacia la
+sierra. En la caja, entre sacos de maíz y bidones de agua, iban once personas y
+dos gallos. El conductor, que había hecho ese viaje dos veces por semana durante
+veinte años, no necesitaba mirar el camino: sabía el nombre de cada curva, de
+cada zanja, de cada árbol caído que había que esquivar. A media mañana pararon
+en un paraje donde había una cruz de madera y una pileta de agua clara. Allí
+comieron tortillas con frijoles y queso, y el más viejo del grupo contó otra vez
+la historia del túnel de la mina, la fiebre del oro del año cuarenta y ocho, y
+cómo el río cambió de curso una noche de tormenta y se llevó la mitad del pueblo
+viejo. Nadie lo interrumpía, aunque todos se la sabían de memoria.""",
+    """In compiler design, register allocation is traditionally formulated as a graph
+coloring problem: build an interference graph whose nodes are program variables
+(live ranges) and whose edges connect variables live at the same program point,
+then color the graph with k colors, where k is the number of available registers.
+Chaitin's allocator spills a variable when no color can be found, inserting load
+and store instructions around the definition and uses, then rebuilding the graph
+because spilling changes live ranges. Linear-scan allocation, by contrast, sorts
+live intervals by start position and walks them once, keeping an active list and
+evicting the interval with the furthest end point when a register is needed -
+a single pass with worse register quality but predictable, fast compilation,
+which made it the standard choice for just-in-time compilers. SSA form makes
+interference sparser: variables defined once interfere only when their live
+ranges overlap, and the dominance ordering of definitions enables coalescing of
+copy instructions through parallel-copy elimination and lost-copy avoidance.""",
+    """# Migration notes: v4 to v5
+
+The v5 release rewrites the storage engine. Read this before upgrading.
+
+**Breaking changes**
+
+1. The manifest format changed from YAML to a length-prefixed binary envelope.
+   Run `ninfer migrate --in place/ --out place2/` once; it is idempotent and
+   verifies every page checksum before touching the destination.
+2. `GET /v4/objects` is removed. Use `GET /v5/objects?cursor=...`; responses
+   now return at most 500 names and include a `next_cursor` field.
+3. Timestamps are microseconds since epoch (int64), not ISO strings.
+
+**Deprecations**
+
+- `--sort-key` still works but is ignored; v5 always returns canonical order.
+- The `x-retention` header moved to the object metadata envelope.
+
+**Operational checklist**
+
+- [ ] Free disk space >= 2.2x the v4 dataset size
+- [ ] Backup of the manifest and at least the two most recent snapshots
+- [ ] Drain writers (v5 tolerates one stale writer for at most 300 seconds)
+- [ ] After migration: `ninfer verify --deep` (about 40 minutes per terabyte)
+
+Rollback: keep the v4 directory until `verify --deep` passes twice in a row.""",
+)
+
+
+def _site_definitions() -> dict[str, str]:
+    """Artifact divisor object name -> checkpoint hook parameter path."""
+
+    sites: dict[str, str] = {}
+    prefix_ck = "language_model.layers."
+    for layer in range(64):
+        layer_ck = f"{prefix_ck}{layer}."
+        layer_art = f"text/layers/{layer}/"
+        is_full = layer in FULL_ATTENTION_LAYERS
+        if is_full:
+            if layer not in EARLY_ATTENTION_INPUT_LAYERS:
+                sites[layer_art + "attention/input_projection/input_scale_divisor"] = (
+                    layer_ck + "self_attn.q_proj"
+                )
+            if layer not in BF16_ATTENTION_OUTPUT_LAYERS:
+                sites[layer_art + "attention/output_projection/input_scale_divisor"] = (
+                    layer_ck + "self_attn.o_proj"
+                )
+        else:
+            sites[layer_art + "gdn/input_projection/input_scale_divisor"] = (
+                layer_ck + "linear_attn.in_proj_qkv"
+            )
+            if layer not in BF16_GDN_OUTPUT_LAYERS:
+                sites[layer_art + "gdn/output_projection/input_scale_divisor"] = (
+                    layer_ck + "linear_attn.out_proj"
+                )
+        if layer not in NVFP4_MLP_LAYERS_FROM_SOURCE:
+            sites[layer_art + "mlp/gate_up_projection/input_scale_divisor"] = (
+                layer_ck + "mlp.gate_proj"
+            )
+            sites[layer_art + "mlp/down_projection/input_scale_divisor"] = (
+                layer_ck + "mlp.down_proj"
+            )
+    return sites
+
+
+# Derivation-check sites: unsloth owns these divisors, we only compare formulas.
+_CHECK_SITES = {
+    f"text/layers/{l}/mlp/gate_up_projection/input_scale_divisor":
+    f"language_model.layers.{l}.mlp.gate_proj"
+    for l in NVFP4_MLP_LAYERS_FROM_SOURCE
+}
+
+
+def _read_source_input_divisors(quantized_dir: Path) -> dict[str, float]:
+    """Read unsloth FP32 scalars by seek; the single large shard cannot be
+    memory-mapped under the host mmap limit."""
+
+    import struct as _struct
+
+    shards = _shard_map(quantized_dir)
+    headers: dict[Path, dict] = {}
+
+    def read_scalar(name: str) -> float:
+        shard = shards[name]
+        if shard not in headers:
+            with shard.open("rb") as handle:
+                length = _struct.unpack("<Q", handle.read(8))[0]
+                header_bytes = handle.read(length)
+                headers[shard] = (json.loads(header_bytes), 8 + length)
+        directory, base = headers[shard]
+        begin = directory[name]["data_offsets"][0]
+        with shard.open("rb") as handle:
+            handle.seek(base + begin)
+            return _struct.unpack("<f", handle.read(4))[0]
+
+    values: dict[str, float] = {}
+    for layer in NVFP4_MLP_LAYERS_FROM_SOURCE:
+        gate = read_scalar(
+            f"model.language_model.layers.{layer}.mlp.gate_proj.input_global_scale"
+        )
+        up = read_scalar(
+            f"model.language_model.layers.{layer}.mlp.up_proj.input_global_scale"
+        )
+        if gate != up:
+            raise ValueError(f"layer {layer}: unsloth gate/up d_x differ")
+        values[f"text/layers/{layer}/mlp/gate_up_projection/input_scale_divisor"] = gate
+    return values
+
+
+def _shard_map(model_dir: Path) -> dict[str, Path]:
+    index = json.loads((model_dir / "model.safetensors.index.json").read_text())
+    shards = {}
+    for name, shard in index["weight_map"].items():
+        shards[name] = model_dir / shard
+    return shards
+
+
+class StreamingLayerLoader:
+    """Materializes one decoder layer's parameters on device per forward call."""
+
+    def __init__(self, model, shards: dict[str, Path], device: torch.device):
+        self._model = model
+        self._shards = shards
+        self._device = device
+        self._handles = []
+        self._open: dict[Path, safe_open] = {}
+
+    def _checkpoint_name(self, param_path: str) -> str:
+        return f"model.{param_path}" if not param_path.startswith("model.") else param_path
+
+    def _parameters_of(self, module: torch.nn.Module, prefix: str):
+        for child_name, child in module.named_children():
+            yield from self._parameters_of(child, f"{prefix}.{child_name}")
+        for attr_name, parameter in list(module._parameters.items()):
+            if parameter is None:
+                continue
+            yield module, attr_name, f"{prefix}.{attr_name}"
+
+    def _install(self, module: torch.nn.Module, attr_name: str, param_path: str) -> None:
+        checkpoint = self._checkpoint_name(param_path)
+        shard = self._shards.get(checkpoint)
+        if shard is None:
+            raise KeyError(f"checkpoint tensor not found: {checkpoint}")
+        if shard not in self._open:
+            self._open[shard] = safe_open(shard, framework="pt", device="cpu")
+        tensor = self._open[shard].get_tensor(checkpoint).to(self._device)
+        module._parameters[attr_name] = torch.nn.Parameter(tensor, requires_grad=False)
+
+    def _evict(self, module: torch.nn.Module, attr_name: str) -> None:
+        parameter = module._parameters[attr_name]
+        module._parameters[attr_name] = torch.nn.Parameter(
+            torch.empty(0, dtype=parameter.dtype, device="meta"),
+            requires_grad=False,
+        )
+
+    def attach(self) -> None:
+        for index, layer in enumerate(self._model.language_model.layers):
+            entries = list(self._parameters_of(layer, f"language_model.layers.{index}"))
+
+            def pre_hook(module, args, kwargs, layer_entries=entries):
+                for module_, attr_name, param_path in layer_entries:
+                    self._install(module_, attr_name, param_path)
+                return args, kwargs
+
+            def post_hook(module, args, output, layer_entries=entries):
+                for module_, attr_name, _ in layer_entries:
+                    self._evict(module_, attr_name)
+
+            self._handles.append(layer.register_forward_pre_hook(pre_hook, with_kwargs=True))
+            self._handles.append(layer.register_forward_hook(post_hook))
+
+    def load_persistent(self) -> None:
+        embedding = self._model.language_model.embed_tokens
+        norm = self._model.language_model.norm
+        for module, attr_name, param_path in (
+            *self._parameters_of(embedding, "language_model.embed_tokens"),
+            *self._parameters_of(norm, "language_model.norm"),
+        ):
+            self._install(module, attr_name, param_path)
+
+    def close(self) -> None:
+        for handle in self._handles:
+            handle.remove()
+        self._open.clear()
+
+
+def _amax_hooks(model, sites: dict[str, str], device: torch.device) -> dict[str, float]:
+    peaks: dict[str, float] = {name: 0.0 for name in sites}
+
+    def capture(site_name: str):
+        def hook(module, args, kwargs):
+            hidden = args[0] if args else kwargs.get("hidden_states")
+            if hidden is None:
+                raise RuntimeError(f"{site_name}: hook captured no input tensor")
+            value = hidden.detach().abs().amax().item()
+            if value > peaks[site_name]:
+                peaks[site_name] = value
+        return hook
+
+    modules = dict(model.named_modules())
+    for site_name, module_path in sites.items():
+        module = modules.get(module_path)
+        if module is None:
+            raise KeyError(f"site module not found: {module_path}")
+        module.register_forward_pre_hook(capture(site_name), with_kwargs=True)
+    return peaks
+
+
+def calibrate(
+    model_dir: str | Path,
+    quantized_dir: str | Path,
+    out_path: str | Path,
+    *,
+    device: str = "cuda",
+) -> Path:
+    base = Path(model_dir)
+    output = Path(out_path)
+    target = torch.device(device)
+    started = time.perf_counter()
+
+    config = AutoConfig.from_pretrained(base, dtype=torch.bfloat16)
+    tokenizer = AutoTokenizer.from_pretrained(base)
+
+    from accelerate import init_empty_weights
+
+    with init_empty_weights(include_buffers=False):
+        from transformers import Qwen3_5Model
+
+        model = Qwen3_5Model(config)
+    model.eval()
+
+    shards = _shard_map(base)
+    loader = StreamingLayerLoader(model, shards, target)
+    loader.load_persistent()
+    for module in model.modules():
+        for buffer_name, buffer in module.named_buffers(recurse=False):
+            if buffer.device.type == "cpu":
+                module._buffers[buffer_name] = buffer.to(target)
+
+    sites = _site_definitions()
+    all_sites = {**sites, **_CHECK_SITES}
+    peaks = _amax_hooks(model, all_sites, target)
+
+    # One concatenated prefill covers the union corpus in a single stream.
+    joined = "\n\n".join(_CALIBRATION_DOCUMENTS)
+    chunk_ids = [tokenizer(joined, return_tensors=None)["input_ids"]]
+
+    loader.attach()
+    with torch.inference_mode():
+        for index, ids in enumerate(chunk_ids, start=1):
+            tokens = torch.tensor([ids], dtype=torch.long, device=target)
+            begin = time.perf_counter()
+            model(tokens, use_cache=False)
+            torch.cuda.synchronize()
+            print(
+                f"chunk {index}/{len(chunk_ids)}: {len(ids)} tokens in "
+                f"{time.perf_counter() - begin:.1f}s",
+                flush=True,
+            )
+    loader.close()
+
+    # Unsloth input divisors for the derivation check. The quantized source is
+    # one large shard; a full mmap can exceed the host mmap limit, so the four
+    # needed bytes per site are read with plain seeks.
+    source_divisors: dict[str, float] = _read_source_input_divisors(
+        Path(quantized_dir)
+    )
+
+    def divisor_for(amax: float) -> float:
+        if amax <= 0.0:
+            raise ValueError("site amax must be positive over a nonempty corpus")
+        return float(torch.tensor(FULL_RANGE / amax).item())
+
+    result = {
+        "encoder_profile": "NVFP4_MAXABS_DIVISOR_RNE_V1",
+        "divisor_formula": "d_x = binary32(2688 / max|site input| over the fixed corpus)",
+        "model_path": str(base.resolve()),
+        "quantized_model_path": str(Path(quantized_dir).resolve()),
+        "corpus_documents": len(_CALIBRATION_DOCUMENTS),
+        "corpus_tokens": sum(len(ids) for ids in chunk_ids),
+        "measured_sites": {},
+        "derivation_check": {},
+    }
+    for name in sites:
+        amax = peaks[name]
+        result["measured_sites"][name] = {
+            "amax": amax,
+            "input_scale_divisor": divisor_for(amax),
+        }
+    for name, source_d_x in source_divisors.items():
+        implied_amax = FULL_RANGE / source_d_x
+        measured = peaks.get(name)
+        result["derivation_check"][name] = {
+            "source_d_x": source_d_x,
+            "implied_amax": implied_amax,
+            "measured_amax": measured,
+            "ratio_measured_over_implied": (measured / implied_amax) if measured else None,
+        }
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as handle:
+        json.dump(result, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    print(
+        f"calibration complete: {len(sites)} sites, {len(source_divisors)} checks, "
+        f"{result['corpus_tokens']} tokens in {time.perf_counter() - started:.1f}s",
+        flush=True,
+    )
+    return output
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--quantized-model", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--device", default="cuda")
+    arguments = parser.parse_args(argv)
+    calibrate(arguments.model, arguments.quantized_model, arguments.out,
+              device=arguments.device)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/convert/qwen3_8_27b/convert_nvfp4full.py
+++ b/tools/convert/qwen3_8_27b/convert_nvfp4full.py
@@ -1,0 +1,422 @@
+"""Build the fuller Qwen3.8-27B NVFP4 artifact from its three source roles.
+
+Canonical invocation::
+
+    python3 -m tools.convert.qwen3_8_27b.convert_nvfp4full \
+      --model /path/to/Qwen3.8-27B \
+      --quantized-model /path/to/Qwen3.8-27B-NVFP4 \
+      --calibration out/qwen3_8_27b_nvfp4full_calibration.json \
+      --out out/qwen3_8_27b_nvfp4full.ninfer
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import struct
+import time
+from typing import Mapping, Sequence
+
+import torch
+
+from tools.artifact.container import (
+    ArtifactIdentity,
+    ArtifactObject,
+    ArtifactWriter,
+)
+from tools.artifact.layouts import encode_direct, encode_nvfp4
+from tools.convert.common.quantize import pick_device
+from tools.convert.common.safetensors import ShardReader
+from tools.convert.qwen3_6.common import conversion as family_conversion
+from tools.convert.qwen3_6_27b import convert as family_config
+from tools.convert.qwen3_6_27b import draft_head
+
+from . import convert as base_convert
+from . import inventory_nvfp4full as inventory
+from . import nvfp4_encode
+from . import recipe_nvfp4full as recipe
+
+
+RECIPE_ID = "qwen3_8_27b_nvfp4full-v1"
+OUTPUT_BASENAME = "qwen3_8_27b_nvfp4full.ninfer"
+
+
+@dataclass(frozen=True, slots=True)
+class ConversionPreflight:
+    base_dir: Path
+    quantized_dir: Path
+    calibration_path: Path
+    config_summary: dict[str, object]
+    base_source: object
+    quantized_dtype_counts: dict[str, int]
+    resources: tuple[family_conversion.ResourcePayload, ...]
+    draft: draft_head.DraftHeadContext
+    object_plan: family_conversion.ObjectPlan
+    divisor_table: recipe.LocalDivisorTable
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _validate_index(model_dir: Path) -> None:
+    index_path = model_dir / "model.safetensors.index.json"
+    value = family_conversion.load_json(index_path)
+    weight_map = value.get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise ValueError(f"{index_path}: weight_map must be a nonempty object")
+    referenced = set(weight_map.values())
+    actual = {path.name for path in model_dir.glob("*.safetensors")}
+    if actual != referenced:
+        raise ValueError(f"{model_dir}: safetensors shard set does not match the index")
+    for shard in sorted(referenced):
+        path = model_dir / shard
+        if not path.is_file() or path.stat().st_size == 0:
+            raise ValueError(f"{path}: indexed shard is missing or empty")
+
+
+def preflight_inventory() -> None:
+    inventory.validate_inventory()
+    recipe.validate_recipe()
+    nvfp4_encode.self_test()
+
+
+def build_object_plan(
+    resources: Mapping[str, bytes],
+) -> family_conversion.ObjectPlan:
+    preflight_inventory()
+    return family_conversion.build_object_plan(inventory.OBJECT_SPECS, resources)
+
+
+def preflight_conversion(
+    base_dir: str | Path,
+    quantized_dir: str | Path,
+    calibration_path: str | Path,
+) -> ConversionPreflight:
+    base = Path(base_dir)
+    quantized = Path(quantized_dir)
+    calibration = Path(calibration_path)
+    _validate_index(base)
+    _validate_index(quantized)
+
+    base_config = family_conversion.load_json(base / "config.json")
+    if base_config.get("quantization_config") is not None:
+        raise ValueError("official source must not declare quantization_config")
+    base_summary = family_config.validate_config(base_config)
+    quantized_summary = family_config.validate_config(
+        family_conversion.load_json(quantized / "config.json")
+    )
+    if base_summary != quantized_summary:
+        raise ValueError("official and quantized source model configs do not match")
+    preflight_inventory()
+
+    with ShardReader(quantized) as quantized_reader:
+        quantized_dtype_counts = recipe.preflight_quantized_metadata(
+            quantized_reader
+        )
+    divisor_table = recipe.LocalDivisorTable(calibration)
+    from tools.convert.qwen3_6.common import recipe as family_recipe
+
+    with ShardReader(base) as base_reader:
+        base_source = family_recipe.preflight_source_reader(
+            base_reader,
+            (
+                *recipe.BASE_DIRECT_RECIPES,
+                *recipe.OFFICIAL_RECIPES_BY_NAME.values(),
+            ),
+        )
+
+    resources = base_convert.load_resources(base)
+    resource_map = {resource.name: resource.data for resource in resources}
+    object_plan = build_object_plan(resource_map)
+    ranking = _repo_root() / draft_head.DEFAULT_RANKING
+    draft = draft_head.compute_shortlist(ranking, base)
+    return ConversionPreflight(
+        base_dir=base,
+        quantized_dir=quantized,
+        calibration_path=calibration,
+        config_summary=base_summary,
+        base_source=base_source,
+        quantized_dtype_counts=quantized_dtype_counts,
+        resources=resources,
+        draft=draft,
+        object_plan=object_plan,
+        divisor_table=divisor_table,
+    )
+
+
+def _encode_source_nvfp4_weight(
+    spec: inventory.TensorSpec, reader: ShardReader
+) -> bytes:
+    selected = recipe.SOURCE_NVFP4_WEIGHTS_BY_NAME[spec.name]
+    packed, scales, divisor = recipe.materialize_source_nvfp4_weight(
+        selected, reader
+    )
+    return encode_nvfp4(packed, scales, divisor, spec.shape)
+
+
+def _encode_local_nvfp4_weight(
+    spec: inventory.TensorSpec, reader: ShardReader, device: torch.device
+) -> tuple[bytes, float, float]:
+    selected = recipe.LOCAL_NVFP4_WEIGHTS_BY_NAME[spec.name]
+    parent = recipe.materialize_bf16_parent(selected.parts, reader)
+    if tuple(parent.shape) != spec.shape or parent.dtype != torch.bfloat16:
+        raise ValueError(f"{spec.name}: materialized parent signature mismatch")
+    words = nvfp4_encode.quantize_nvfp4(parent, device=device)
+    payload = encode_nvfp4(
+        words.packed_codes.cpu(),
+        words.natural_scales.cpu(),
+        struct.pack("<f", words.weight_divisor),
+        spec.shape,
+    )
+    error = nvfp4_encode.relative_frobenius_error(
+        parent, nvfp4_encode.dequantize_nvfp4(words)
+    )
+    del parent
+    return payload, float(words.weight_divisor), error
+
+
+def _encode_bf16_exception(
+    spec: inventory.TensorSpec, reader: ShardReader
+) -> bytes:
+    selected = recipe.BF16_WEIGHTS_BY_NAME[spec.name]
+    parent = recipe.materialize_bf16_parent(selected.parts, reader)
+    if tuple(parent.shape) != spec.shape or parent.dtype != torch.bfloat16:
+        raise ValueError(f"{spec.name}: materialized BF16 parent signature mismatch")
+    return encode_direct(parent, inventory.BF16)
+
+
+def _materialize_base_direct(spec: inventory.TensorSpec, reader: ShardReader) -> bytes:
+    tensor = family_recipe_materialize(
+        recipe.BASE_DIRECT_BY_NAME[spec.name], reader
+    )
+    if tuple(tensor.shape) != spec.shape:
+        raise ValueError(
+            f"{spec.name}: materialized shape {tuple(tensor.shape)} != {spec.shape}"
+        )
+    return encode_direct(tensor, spec.format)
+
+
+def family_recipe_materialize(
+    tensor_recipe, reader: ShardReader, derived=None
+) -> torch.Tensor:
+    from tools.convert.qwen3_6.common import recipe as family_recipe
+
+    return family_recipe.materialize_recipe(tensor_recipe, reader, derived)
+
+
+def _materialize_official(
+    spec: inventory.TensorSpec,
+    reader: ShardReader,
+    derived: Mapping[str, torch.Tensor],
+    device: torch.device,
+) -> bytes:
+    tensor = family_recipe_materialize(
+        recipe.OFFICIAL_RECIPES_BY_NAME[spec.name], reader, dict(derived)
+    )
+    if tuple(tensor.shape) != spec.shape:
+        raise ValueError(
+            f"{spec.name}: materialized shape {tuple(tensor.shape)} != {spec.shape}"
+        )
+    payload = family_conversion.encode_tensor_payload(tensor, spec, device)
+    del tensor
+    return payload
+
+
+def _build_report(
+    *,
+    preflight: ConversionPreflight,
+    output: Path,
+    arguments: Mapping[str, object],
+    objects: Sequence[ArtifactObject],
+    elapsed_seconds: float,
+    final_bytes: int,
+    device: torch.device,
+    quantization: Mapping[str, object],
+) -> dict[str, object]:
+    ranking = _repo_root() / draft_head.DEFAULT_RANKING
+    report = family_conversion.build_conversion_report(
+        identity=ArtifactIdentity(inventory.MODEL_ID, inventory.WEIGHTS_ID),
+        target_key=inventory.TARGET_KEY,
+        recipe_id=RECIPE_ID,
+        repo_root=_repo_root(),
+        model_dir=preflight.base_dir,
+        out_path=output,
+        arguments=arguments,
+        config_summary=preflight.config_summary,
+        source_preflight=preflight.base_source,
+        objects=objects,
+        elapsed_seconds=elapsed_seconds,
+        final_bytes=final_bytes,
+        device=device,
+        ranking_path=ranking,
+    )
+    report["source"] = {
+        "base": {
+            "repository": recipe.BASE_REPOSITORY,
+            "revision": recipe.BASE_REVISION,
+            "model_path": str(preflight.base_dir.resolve()),
+        },
+        "quantized": {
+            "repository": recipe.QUANTIZED_REPOSITORY,
+            "revision": recipe.QUANTIZED_REVISION,
+            "model_path": str(preflight.quantized_dir.resolve()),
+            "note": (
+                "document-pinned revision 60e813d4dbbdc5d64cf3f5a8caf2897bedf03679 "
+                "is no longer reachable upstream; this reachable main revision "
+                "carries the structurally validated mixed-precision allocation"
+            ),
+        },
+        "calibration": {
+            "path": str(preflight.calibration_path.resolve()),
+            **preflight.divisor_table.provenance,
+        },
+        "ranking_path": str(ranking.resolve()),
+    }
+    report["local_nvfp4"] = quantization
+    return report
+
+
+def convert(
+    base_dir: str | Path,
+    quantized_dir: str | Path,
+    calibration_path: str | Path,
+    out_path: str | Path,
+    *,
+    device: str | torch.device = "cuda",
+) -> Path:
+    """Run the closed three-source conversion and return its report path."""
+
+    started = time.perf_counter()
+    output = Path(out_path)
+    if output.name != OUTPUT_BASENAME:
+        raise ValueError(
+            f"nvfp4full converter output basename must be {OUTPUT_BASENAME!r}"
+        )
+    requested_device = str(device)
+    resolved_device = pick_device(device)
+    preflight = preflight_conversion(base_dir, quantized_dir, calibration_path)
+
+    print(
+        f"preflight complete: {len(preflight.object_plan.objects)} objects, "
+        f"{len(recipe.SOURCE_NVFP4_WEIGHT_RECIPES)} source and "
+        f"{len(recipe.LOCAL_NVFP4_WEIGHT_RECIPES)} local NVFP4 parents, "
+        f"device={resolved_device}",
+        flush=True,
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    resources = {resource.name: resource.data for resource in preflight.resources}
+    draft_ids = draft_head.materialize_draft_head_token_ids(preflight.draft)
+    derived = {draft_head.DRAFT_HEAD_TOKEN_IDS_OBJECT: draft_ids}
+    quantization_report: dict[str, object] = {
+        "encoder_profile": recipe.LOCAL_ENCODER_PROFILE,
+        "parents": {},
+    }
+    with ShardReader(preflight.base_dir) as base_reader, ShardReader(
+        preflight.quantized_dir
+    ) as quantized_reader:
+        with ArtifactWriter(
+            output,
+            ArtifactIdentity(inventory.MODEL_ID, inventory.WEIGHTS_ID),
+            preflight.object_plan.specs,
+        ) as writer:
+            if writer.objects != preflight.object_plan.objects:
+                raise RuntimeError(
+                    "writer object plan differs from completed preflight"
+                )
+            for index, spec in enumerate(inventory.OBJECT_SPECS, start=1):
+                if isinstance(spec, inventory.ResourceSpec):
+                    payload = resources[spec.name]
+                elif spec.name in recipe.SOURCE_NVFP4_WEIGHTS_BY_NAME:
+                    payload = _encode_source_nvfp4_weight(spec, quantized_reader)
+                elif spec.name in recipe.LOCAL_NVFP4_WEIGHTS_BY_NAME:
+                    payload, divisor, error = _encode_local_nvfp4_weight(
+                        spec, base_reader, resolved_device
+                    )
+                    quantization_report["parents"][spec.name] = {
+                        "weight_scale_divisor": divisor,
+                        "relative_frobenius_error": error,
+                    }
+                elif spec.name in recipe.SOURCE_INPUT_DIVISORS_BY_NAME:
+                    scalar = recipe.materialize_source_input_divisor(
+                        recipe.SOURCE_INPUT_DIVISORS_BY_NAME[spec.name],
+                        quantized_reader,
+                    )
+                    payload = encode_direct(scalar, inventory.FP32)
+                elif spec.name in recipe.LOCAL_INPUT_DIVISORS_BY_NAME:
+                    scalar = preflight.divisor_table.value(spec.name)
+                    payload = encode_direct(scalar, inventory.FP32)
+                elif spec.name in recipe.BF16_WEIGHTS_BY_NAME:
+                    payload = _encode_bf16_exception(spec, base_reader)
+                elif spec.name in recipe.BASE_DIRECT_BY_NAME:
+                    payload = _materialize_base_direct(spec, base_reader)
+                else:
+                    payload = _materialize_official(
+                        spec, base_reader, derived, resolved_device
+                    )
+                writer.write(spec.name, payload)
+                del payload
+                if index % 64 == 0 or index == len(inventory.OBJECT_SPECS):
+                    print(
+                        f"[{index}/{len(inventory.OBJECT_SPECS)}] objects written",
+                        flush=True,
+                    )
+
+    errors = [
+        entry["relative_frobenius_error"]
+        for entry in quantization_report["parents"].values()
+    ]
+    quantization_report["relative_frobenius_error_max"] = max(errors)
+    quantization_report["relative_frobenius_error_mean"] = sum(errors) / len(errors)
+
+    elapsed = time.perf_counter() - started
+    final_bytes = output.stat().st_size
+    arguments = {
+        "model": str(base_dir),
+        "quantized_model": str(quantized_dir),
+        "calibration": str(calibration_path),
+        "out": str(out_path),
+        "device": requested_device,
+    }
+    report = _build_report(
+        preflight=preflight,
+        output=output,
+        arguments=arguments,
+        objects=preflight.object_plan.objects,
+        elapsed_seconds=elapsed,
+        final_bytes=final_bytes,
+        device=resolved_device,
+        quantization=quantization_report,
+    )
+    report_path = Path(str(output) + ".conversion.json")
+    with report_path.open("w", encoding="utf-8") as handle:
+        json.dump(report, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    print(
+        f"complete: {final_bytes} bytes in {elapsed:.1f}s; report={report_path}",
+        flush=True,
+    )
+    return report_path
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--quantized-model", required=True, type=Path)
+    parser.add_argument("--calibration", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--device", default="cuda")
+    arguments = parser.parse_args(argv)
+    convert(
+        arguments.model,
+        arguments.quantized_model,
+        arguments.calibration,
+        arguments.out,
+        device=arguments.device,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/convert/qwen3_8_27b/inventory_nvfp4full.py
+++ b/tools/convert/qwen3_8_27b/inventory_nvfp4full.py
@@ -1,0 +1,477 @@
+"""Persistent-object contract for the fuller Qwen3.8-27B NVFP4 artifact."""
+
+from __future__ import annotations
+
+from tools.convert.qwen3_6.common.inventory import (
+    BF16,
+    CONTIGUOUS_LAYOUT,
+    FP32,
+    I32,
+    LogicalAliasSpec,
+    LogicalRowViewSpec,
+    Q4,
+    Q5,
+    Q6,
+    RESOURCE_SPECS,
+    ROW_SPLIT_LAYOUT,
+    ResourceSpec,
+    StoredObjectSpec,
+    TensorSpec,
+    W8,
+    build_vision_specs,
+)
+
+
+MODEL_ID = "qwen3.8-27b"
+WEIGHTS_ID = "nvfp4full"
+TARGET_KEY = "qwen3_8_27b"
+
+NVFP4 = "NVFP4"
+BLOCK_SCALE_LAYOUT = "blockscale-k16-m128x4-v1"
+
+FULL_ATTENTION_LAYERS = tuple(range(3, 64, 4))
+GDN_LAYERS = tuple(layer for layer in range(64) if layer not in FULL_ATTENTION_LAYERS)
+
+# Text allocation: the registered Qwen3.6-27B NVFP4 exception pattern applied to
+# the Qwen3.8 checkpoint and object naming.
+EARLY_ATTENTION_INPUT_LAYERS = (3, 7, 11, 15, 19, 23)
+NVFP4_ATTENTION_INPUT_LAYERS = tuple(
+    layer for layer in FULL_ATTENTION_LAYERS
+    if layer not in EARLY_ATTENTION_INPUT_LAYERS
+)
+BF16_ATTENTION_OUTPUT_LAYERS = (3, 7)
+NVFP4_ATTENTION_OUTPUT_LAYERS = tuple(
+    layer for layer in FULL_ATTENTION_LAYERS
+    if layer not in BF16_ATTENTION_OUTPUT_LAYERS
+)
+BF16_GDN_OUTPUT_LAYERS = (4,)
+NVFP4_GDN_OUTPUT_LAYERS = tuple(
+    layer for layer in GDN_LAYERS if layer not in BF16_GDN_OUTPUT_LAYERS
+)
+# Quantized-source MLP parents (words copied verbatim); every other NVFP4
+# parent is locally quantized from the official BF16 source.
+SOURCE_NVFP4_MLP_LAYERS = tuple(range(56))
+
+FORMAT_NAMES = (BF16, FP32, I32, Q4, Q5, Q6, W8, NVFP4)
+LAYOUT_NAMES = (CONTIGUOUS_LAYOUT, ROW_SPLIT_LAYOUT, BLOCK_SCALE_LAYOUT)
+
+
+def tensor_spec(
+    name: str,
+    shape: tuple[int, ...],
+    numeric_format: str,
+) -> TensorSpec:
+    if numeric_format in (BF16, FP32, I32):
+        layout = CONTIGUOUS_LAYOUT
+    elif numeric_format in (Q4, Q5, Q6, W8):
+        layout = ROW_SPLIT_LAYOUT
+    elif numeric_format == NVFP4:
+        layout = BLOCK_SCALE_LAYOUT
+    else:
+        raise ValueError(f"unsupported Qwen3.8 nvfp4full format: {numeric_format}")
+    return TensorSpec(name, shape, numeric_format, layout)
+
+
+def _input_scale_divisor_name(matrix_name: str) -> str | None:
+    prefix, suffix = matrix_name.rsplit("/", 1)
+    if suffix == "query_key_gate_value" and prefix.endswith("/attention"):
+        return prefix + "/input_projection/input_scale_divisor"
+    if suffix == "output" and prefix.endswith("/attention"):
+        return prefix + "/output_projection/input_scale_divisor"
+    if suffix == "query_key_value_z" and prefix.endswith("/gdn"):
+        return prefix + "/input_projection/input_scale_divisor"
+    if suffix == "output" and prefix.endswith("/gdn"):
+        return prefix + "/output_projection/input_scale_divisor"
+    if suffix == "gate_up" and prefix.endswith("/mlp"):
+        return prefix + "/gate_up_projection/input_scale_divisor"
+    if suffix == "down" and prefix.endswith("/mlp"):
+        return prefix + "/down_projection/input_scale_divisor"
+    return None
+
+
+def _build_text_core_specs() -> tuple[TensorSpec, ...]:
+    specs: list[TensorSpec] = [tensor_spec("text/token_embedding", (248320, 5120), W8)]
+
+    def emit(name: str, shape: tuple[int, ...], numeric_format: str) -> None:
+        specs.append(tensor_spec(name, shape, numeric_format))
+        if numeric_format == NVFP4:
+            specs.append(
+                tensor_spec(_input_scale_divisor_name(name), (), FP32)
+            )
+
+    for layer in range(64):
+        prefix = f"text/layers/{layer}/"
+        emit(prefix + "input_norm", (5120,), BF16)
+        if layer in FULL_ATTENTION_LAYERS:
+            emit(
+                prefix + "attention/query_key_gate_value",
+                (14336, 5120),
+                BF16 if layer in EARLY_ATTENTION_INPUT_LAYERS else NVFP4,
+            )
+            emit(prefix + "attention/query_norm", (256,), BF16)
+            emit(prefix + "attention/key_norm", (256,), BF16)
+            emit(
+                prefix + "attention/output",
+                (5120, 6144),
+                BF16 if layer in BF16_ATTENTION_OUTPUT_LAYERS else NVFP4,
+            )
+        else:
+            emit(prefix + "gdn/a_log", (48,), FP32)
+            emit(prefix + "gdn/dt_bias", (48,), FP32)
+            emit(prefix + "gdn/convolution", (4, 10240), BF16)
+            emit(prefix + "gdn/a_b_projection", (96, 5120), BF16)
+            emit(prefix + "gdn/query_key_value_z", (16384, 5120), NVFP4)
+            emit(prefix + "gdn/norm", (128,), BF16)
+            emit(
+                prefix + "gdn/output",
+                (5120, 6144),
+                BF16 if layer in BF16_GDN_OUTPUT_LAYERS else NVFP4,
+            )
+        emit(prefix + "post_attention_norm", (5120,), BF16)
+        emit(prefix + "mlp/gate_up", (34816, 5120), NVFP4)
+        emit(prefix + "mlp/down", (5120, 17408), NVFP4)
+
+    emit("text/final_norm", (5120,), BF16)
+    emit("text/output_head", (248320, 5120), W8)
+    return tuple(specs)
+
+
+def _build_draft_head_specs() -> tuple[TensorSpec, ...]:
+    return (
+        tensor_spec("text/draft_head", (131072, 5120), Q4),
+        tensor_spec("text/draft_head_token_ids", (131072,), I32),
+    )
+
+
+def _build_mtp_specs() -> tuple[TensorSpec, ...]:
+    return (
+        tensor_spec("mtp/input_projection", (5120, 10240), W8),
+        tensor_spec("mtp/embedding_norm", (5120,), BF16),
+        tensor_spec("mtp/hidden_norm", (5120,), BF16),
+        tensor_spec("mtp/layer/input_norm", (5120,), BF16),
+        tensor_spec(
+            "mtp/layer/attention/query_key_gate_value", (14336, 5120), W8
+        ),
+        tensor_spec("mtp/layer/attention/query_norm", (256,), BF16),
+        tensor_spec("mtp/layer/attention/key_norm", (256,), BF16),
+        tensor_spec("mtp/layer/attention/output", (5120, 6144), W8),
+        tensor_spec("mtp/layer/post_attention_norm", (5120,), BF16),
+        tensor_spec("mtp/layer/mlp/gate_up", (34816, 5120), W8),
+        tensor_spec("mtp/layer/mlp/down", (5120, 17408), W8),
+        tensor_spec("mtp/final_norm", (5120,), BF16),
+    )
+
+
+TEXT_CORE_TENSOR_SPECS = _build_text_core_specs()
+DRAFT_HEAD_TENSOR_SPECS = _build_draft_head_specs()
+MTP_TENSOR_SPECS = _build_mtp_specs()
+VISION_TENSOR_SPECS = build_vision_specs(5120)
+
+TENSOR_SPECS = (
+    TEXT_CORE_TENSOR_SPECS
+    + DRAFT_HEAD_TENSOR_SPECS
+    + MTP_TENSOR_SPECS
+    + VISION_TENSOR_SPECS
+)
+OBJECT_SPECS: tuple[StoredObjectSpec, ...] = RESOURCE_SPECS + TENSOR_SPECS
+
+FORMAT_COUNTS = {
+    numeric_format: sum(spec.format == numeric_format for spec in TENSOR_SPECS)
+    for numeric_format in FORMAT_NAMES
+}
+LAYOUT_COUNTS = {
+    layout: sum(spec.layout == layout for spec in TENSOR_SPECS)
+    for layout in LAYOUT_NAMES
+}
+
+LOGICAL_ROW_VIEW_SPECS = (
+    LogicalRowViewSpec(
+        "text/layers/{l}/attention/query",
+        "text/layers/{l}/attention/query_key_gate_value",
+        0,
+        6144,
+        (6144, 5120),
+        FULL_ATTENTION_LAYERS,
+    ),
+    LogicalRowViewSpec(
+        "text/layers/{l}/attention/key",
+        "text/layers/{l}/attention/query_key_gate_value",
+        6144,
+        7168,
+        (1024, 5120),
+        FULL_ATTENTION_LAYERS,
+    ),
+    LogicalRowViewSpec(
+        "text/layers/{l}/attention/output_gate",
+        "text/layers/{l}/attention/query_key_gate_value",
+        7168,
+        13312,
+        (6144, 5120),
+        FULL_ATTENTION_LAYERS,
+    ),
+    LogicalRowViewSpec(
+        "text/layers/{l}/attention/value",
+        "text/layers/{l}/attention/query_key_gate_value",
+        13312,
+        14336,
+        (1024, 5120),
+        FULL_ATTENTION_LAYERS,
+    ),
+    LogicalRowViewSpec(
+        "text/layers/{l}/gdn/query",
+        "text/layers/{l}/gdn/query_key_value_z",
+        0,
+        2048,
+        (2048, 5120),
+        GDN_LAYERS,
+    ),
+    LogicalRowViewSpec(
+        "text/layers/{l}/gdn/key",
+        "text/layers/{l}/gdn/query_key_value_z",
+        2048,
+        4096,
+        (2048, 5120),
+        GDN_LAYERS,
+    ),
+    LogicalRowViewSpec(
+        "text/layers/{l}/gdn/value",
+        "text/layers/{l}/gdn/query_key_value_z",
+        4096,
+        10240,
+        (6144, 5120),
+        GDN_LAYERS,
+    ),
+    LogicalRowViewSpec(
+        "text/layers/{l}/gdn/z",
+        "text/layers/{l}/gdn/query_key_value_z",
+        10240,
+        16384,
+        (6144, 5120),
+        GDN_LAYERS,
+    ),
+    LogicalRowViewSpec(
+        "text/layers/{l}/gdn/a_projection",
+        "text/layers/{l}/gdn/a_b_projection",
+        0,
+        48,
+        (48, 5120),
+        GDN_LAYERS,
+    ),
+    LogicalRowViewSpec(
+        "text/layers/{l}/gdn/b_projection",
+        "text/layers/{l}/gdn/a_b_projection",
+        48,
+        96,
+        (48, 5120),
+        GDN_LAYERS,
+    ),
+    LogicalRowViewSpec(
+        "text/layers/{l}/mlp/gate",
+        "text/layers/{l}/mlp/gate_up",
+        0,
+        17408,
+        (17408, 5120),
+        tuple(range(64)),
+    ),
+    LogicalRowViewSpec(
+        "text/layers/{l}/mlp/up",
+        "text/layers/{l}/mlp/gate_up",
+        17408,
+        34816,
+        (17408, 5120),
+        tuple(range(64)),
+    ),
+    LogicalRowViewSpec(
+        "mtp/layer/attention/query",
+        "mtp/layer/attention/query_key_gate_value",
+        0,
+        6144,
+        (6144, 5120),
+        None,
+    ),
+    LogicalRowViewSpec(
+        "mtp/layer/attention/key",
+        "mtp/layer/attention/query_key_gate_value",
+        6144,
+        7168,
+        (1024, 5120),
+        None,
+    ),
+    LogicalRowViewSpec(
+        "mtp/layer/attention/output_gate",
+        "mtp/layer/attention/query_key_gate_value",
+        7168,
+        13312,
+        (6144, 5120),
+        None,
+    ),
+    LogicalRowViewSpec(
+        "mtp/layer/attention/value",
+        "mtp/layer/attention/query_key_gate_value",
+        13312,
+        14336,
+        (1024, 5120),
+        None,
+    ),
+    LogicalRowViewSpec(
+        "mtp/layer/mlp/gate",
+        "mtp/layer/mlp/gate_up",
+        0,
+        17408,
+        (17408, 5120),
+        None,
+    ),
+    LogicalRowViewSpec(
+        "mtp/layer/mlp/up",
+        "mtp/layer/mlp/gate_up",
+        17408,
+        34816,
+        (17408, 5120),
+        None,
+    ),
+)
+
+ALIAS_SPECS = (
+    LogicalAliasSpec("mtp/token_embedding", ("text/token_embedding",)),
+    LogicalAliasSpec("mtp/full_output_head", ("text/output_head",)),
+    LogicalAliasSpec(
+        "mtp/optimized_proposal_head",
+        ("text/draft_head", "text/draft_head_token_ids"),
+    ),
+    LogicalAliasSpec(
+        "text/layers/{l}/gdn/channel_major_convolution",
+        ("text/layers/{l}/gdn/convolution",),
+        layers=GDN_LAYERS,
+        axis_order=(1, 0),
+    ),
+)
+
+NVFP4_TENSOR_SPECS = tuple(spec for spec in TENSOR_SPECS if spec.format == NVFP4)
+INPUT_SCALE_DIVISOR_SPECS = tuple(
+    spec
+    for spec in TENSOR_SPECS
+    if spec.format == FP32 and spec.name.endswith("/input_scale_divisor")
+)
+SOURCE_NVFP4_WEIGHT_SPECS = tuple(
+    spec
+    for spec in NVFP4_TENSOR_SPECS
+    if spec.name.startswith("text/layers/")
+    and int(spec.name.split("/")[2]) in SOURCE_NVFP4_MLP_LAYERS
+    and spec.name.endswith(("/mlp/gate_up", "/mlp/down"))
+)
+LOCAL_NVFP4_WEIGHT_SPECS = tuple(
+    spec for spec in NVFP4_TENSOR_SPECS if spec not in SOURCE_NVFP4_WEIGHT_SPECS
+)
+BF16_EXCEPTION_SPECS = tuple(
+    spec
+    for spec in TEXT_CORE_TENSOR_SPECS
+    if spec.format == BF16
+    and spec.name.endswith(
+        (
+            "attention/query_key_gate_value",
+            "attention/output",
+            "gdn/output",
+        )
+    )
+)
+
+
+def validate_inventory() -> None:
+    names = tuple(spec.name for spec in OBJECT_SPECS)
+    if len(names) != len(set(names)):
+        raise ValueError("Qwen3.8 nvfp4full inventory contains duplicate names")
+    if (
+        len(TEXT_CORE_TENSOR_SPECS),
+        len(DRAFT_HEAD_TENSOR_SPECS),
+        len(MTP_TENSOR_SPECS),
+        len(VISION_TENSOR_SPECS),
+        len(TENSOR_SPECS),
+        len(OBJECT_SPECS),
+        len(NVFP4_TENSOR_SPECS),
+        len(INPUT_SCALE_DIVISOR_SPECS),
+        len(SOURCE_NVFP4_WEIGHT_SPECS),
+        len(LOCAL_NVFP4_WEIGHT_SPECS),
+    ) != (906, 2, 12, 333, 1253, 1259, 247, 247, 112, 135):
+        raise ValueError("Qwen3.8 nvfp4full inventory is incomplete")
+    if FORMAT_COUNTS != {
+        BF16: 543,
+        FP32: 343,
+        I32: 1,
+        Q4: 55,
+        Q5: 54,
+        Q6: 1,
+        W8: 9,
+        NVFP4: 247,
+    }:
+        raise ValueError(f"unexpected numeric allocation: {FORMAT_COUNTS}")
+    if LAYOUT_COUNTS != {
+        CONTIGUOUS_LAYOUT: 887,
+        ROW_SPLIT_LAYOUT: 119,
+        BLOCK_SCALE_LAYOUT: 247,
+    }:
+        raise ValueError(f"unexpected layout allocation: {LAYOUT_COUNTS}")
+    for spec in NVFP4_TENSOR_SPECS:
+        scalar = _input_scale_divisor_name(spec.name)
+        if scalar is None:
+            raise ValueError(f"NVFP4 parent {spec.name} has no divisor site name")
+    divisor_names = {spec.name for spec in INPUT_SCALE_DIVISOR_SPECS}
+    expected = {
+        _input_scale_divisor_name(spec.name) for spec in NVFP4_TENSOR_SPECS
+    }
+    if divisor_names != expected:
+        raise ValueError("NVFP4 divisor sites do not cover the NVFP4 parents")
+    if len(BF16_EXCEPTION_SPECS) != 9:
+        raise ValueError(f"expected nine BF16 exception parents, got {len(BF16_EXCEPTION_SPECS)}")
+
+
+validate_inventory()
+
+
+__all__ = [
+    "ALIAS_SPECS",
+    "BF16",
+    "BF16_ATTENTION_OUTPUT_LAYERS",
+    "BF16_EXCEPTION_SPECS",
+    "BF16_GDN_OUTPUT_LAYERS",
+    "BLOCK_SCALE_LAYOUT",
+    "CONTIGUOUS_LAYOUT",
+    "DRAFT_HEAD_TENSOR_SPECS",
+    "EARLY_ATTENTION_INPUT_LAYERS",
+    "FORMAT_COUNTS",
+    "FORMAT_NAMES",
+    "FP32",
+    "FULL_ATTENTION_LAYERS",
+    "GDN_LAYERS",
+    "I32",
+    "INPUT_SCALE_DIVISOR_SPECS",
+    "LAYOUT_COUNTS",
+    "LAYOUT_NAMES",
+    "LOCAL_NVFP4_WEIGHT_SPECS",
+    "LOGICAL_ROW_VIEW_SPECS",
+    "MODEL_ID",
+    "MTP_TENSOR_SPECS",
+    "NVFP4",
+    "NVFP4_ATTENTION_INPUT_LAYERS",
+    "NVFP4_ATTENTION_OUTPUT_LAYERS",
+    "NVFP4_GDN_OUTPUT_LAYERS",
+    "NVFP4_TENSOR_SPECS",
+    "OBJECT_SPECS",
+    "Q4",
+    "Q5",
+    "Q6",
+    "RESOURCE_SPECS",
+    "ROW_SPLIT_LAYOUT",
+    "ResourceSpec",
+    "SOURCE_NVFP4_MLP_LAYERS",
+    "SOURCE_NVFP4_WEIGHT_SPECS",
+    "StoredObjectSpec",
+    "TARGET_KEY",
+    "TENSOR_SPECS",
+    "TEXT_CORE_TENSOR_SPECS",
+    "TensorSpec",
+    "VISION_TENSOR_SPECS",
+    "W8",
+    "WEIGHTS_ID",
+    "tensor_spec",
+    "validate_inventory",
+]

--- a/tools/convert/qwen3_8_27b/nvfp4_encode.py
+++ b/tools/convert/qwen3_8_27b/nvfp4_encode.py
@@ -1,0 +1,296 @@
+"""Local NVFP4 weight encoder for the fuller Qwen3.8-27B NVFP4 artifact.
+
+Encoder profile ``NVFP4_MAXABS_DIVISOR_RNE_V1``: for one logical BF16 parent
+``W [N,K]`` with ``K % 16 == 0``, all arithmetic round-to-nearest-even:
+
+    amax = max(|W|)
+    d_w  = binary32(2688 / amax)         # 2688 = 6 * 448; d_w = 1 when amax = 0
+    y    = binary32(W * d_w)
+    per K-group g of 16:
+        ab = max(|y| in g)
+        s  = E4M3FN(min(ab / 6, 448))    # +0 when ab = 0 or the cast rounds to 0
+        q  = E2M1(y / decode(s))         # ties-to-even, saturating to +-6; s = 0 -> q = +0
+
+The stored weight decodes exactly as the registered NVFP4 contract:
+``W_hat = decode_e2m1(q) * decode_e4m3fn(s) / d_w``. Site-level input divisors
+``d_x`` use the same orientation (``d_x = binary32(2688 / max|site input|)``) so
+one block scale ``E4M3FN(d_x * max_abs(block) / 6)`` fills the A4 range.
+
+This module is the bit-level oracle owner for the E2M1 and E4M3FN words it
+emits; every produced payload is round-trip verified against
+``tools.artifact.layouts`` word decoding before it is written.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import struct
+
+import torch
+
+from tools.artifact.layouts import decode_nvfp4_words, encode_nvfp4
+
+
+ENCODER_PROFILE = "NVFP4_MAXABS_DIVISOR_RNE_V1"
+
+# 6 * 448: the largest product of an E2M1 magnitude and an E4M3FN magnitude.
+_FULL_RANGE = 2688.0
+
+# Positive E2M1 magnitudes and the RNE tie boundaries between them. A tie at a
+# boundary selects the neighbor whose retained significand bit is even.
+_E2M1_MAGNITUDES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+_E2M1_BOUNDARIES = (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0)
+_E2M1_TIE_UP = (False, True, False, True, False, True, False)
+
+
+def _e2m1_decode_table() -> torch.Tensor:
+    values = []
+    for code in range(16):
+        magnitude = _E2M1_MAGNITUDES[code & 7]
+        values.append(-magnitude if code & 8 else magnitude)
+    return torch.tensor(values, dtype=torch.float32)
+
+
+def _e4m3fn_decode_table(device: torch.device) -> torch.Tensor:
+    codes = torch.arange(256, dtype=torch.uint8, device=device)
+    bits = codes.to(torch.int32)
+    sign = torch.where((bits & 0x80) != 0, -1.0, 1.0)
+    exponent = (bits >> 3) & 0xF
+    fraction = bits & 0x7
+    normal = (exponent >= 1) & (exponent <= 15)
+    normal_or_special = (exponent == 15) & (fraction < 7)
+    value = torch.where(
+        normal | normal_or_special,
+        sign * (1.0 + fraction / 8.0) * torch.pow(
+            2.0, (exponent - 7).to(torch.float32)
+        ),
+        torch.where(
+            (exponent == 0) & (fraction != 0),
+            sign * fraction * 2.0**-9,
+            torch.zeros_like(sign),
+        ),
+    )
+    # e == 15, m == 7 is NaN; it is never produced and decodes to NaN here.
+    nan_mask = (exponent == 15) & (fraction == 7)
+    return torch.where(nan_mask, torch.full_like(value, float("nan")), value)
+
+
+def e2m1_rne_codes(values: torch.Tensor) -> torch.Tensor:
+    """Round finite FP32 values to saturating E2M1 codes (0..15, sign bit 3).
+
+    Ties at ``0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0`` select the neighbor with
+    the even retained significand bit; magnitudes above 5 saturate at 6; signed
+    zero keeps its sign.
+    """
+
+    sign_bits = torch.where(
+        torch.signbit(values), torch.tensor(8, dtype=torch.uint8, device=values.device),
+        torch.tensor(0, dtype=torch.uint8, device=values.device),
+    )
+    magnitude = values.abs()
+    code = torch.zeros_like(magnitude, dtype=torch.long)
+    for index, boundary in enumerate(_E2M1_BOUNDARIES):
+        step_up = magnitude > boundary
+        tie_up = (magnitude == boundary) & _E2M1_TIE_UP[index]
+        code = torch.where(step_up | tie_up, code + 1, code)
+    nibble = torch.gather(
+        torch.tensor([0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device=values.device),
+        0,
+        code.reshape(-1),
+    ).reshape(code.shape)
+    return nibble | sign_bits
+
+
+def _pack_e2m1_pairs(codes: torch.Tensor) -> torch.Tensor:
+    """Pack adjacent K codes into bytes: low nibble is the smaller K."""
+
+    pairs = codes.reshape(codes.shape[0], -1, 2)
+    return (pairs[:, :, 0] | (pairs[:, :, 1] << 4)).to(torch.uint8)
+
+
+@dataclass(frozen=True, slots=True)
+class Nvfp4Words:
+    packed_codes: torch.Tensor  # uint8 [N, K/2]
+    natural_scales: torch.Tensor  # uint8 [N, K/16]
+    weight_divisor: float  # positive finite FP32 value
+
+
+def quantize_nvfp4(
+    weight: torch.Tensor,
+    *,
+    device: str | torch.device = "cuda",
+) -> Nvfp4Words:
+    """Quantize one logical BF16/FP32 ``[N,K]`` parent under the profile above."""
+
+    if weight.dim() != 2 or weight.shape[1] % 16 != 0:
+        raise ValueError("NVFP4 parents require rank 2 with K divisible by 16")
+    target = torch.device(device)
+    source = weight.detach().to(device=target, dtype=torch.float32)
+    if not torch.isfinite(source).all():
+        raise ValueError("NVFP4 source contains NaN or infinity")
+
+    rows, columns = source.shape
+    amax = source.abs().amax().item()
+    divisor = 1.0 if amax == 0.0 else float(torch.tensor(_FULL_RANGE / amax).item())
+    divisor32 = struct.unpack("<f", struct.pack("<f", divisor))[0]
+    if divisor32 <= 0.0 or divisor32 != divisor32:
+        raise ValueError("NVFP4 weight divisor is not finite and positive")
+    divisor_word = torch.tensor(divisor32, dtype=torch.float32, device=target)
+
+    scaled = source * divisor_word
+    blocks = scaled.reshape(rows, columns // 16, 16)
+    block_amax = blocks.abs().amax(dim=2)
+    scale_target = (block_amax / 6.0).clamp(max=448.0)
+    scales = scale_target.to(torch.float8_e4m3fn).view(torch.uint8)
+    scale_values = scales.view(torch.float8_e4m3fn).to(torch.float32)
+
+    nonzero = scale_values > 0
+    ratio = torch.where(
+        nonzero.unsqueeze(-1),
+        blocks / torch.where(nonzero, scale_values, torch.ones_like(scale_values)).unsqueeze(-1),
+        torch.zeros_like(blocks),
+    )
+    codes = e2m1_rne_codes(ratio)
+    return Nvfp4Words(
+        packed_codes=_pack_e2m1_pairs(codes.reshape(rows, columns)),
+        natural_scales=scales.reshape(rows, columns // 16).contiguous(),
+        weight_divisor=divisor32,
+    )
+
+
+def dequantize_nvfp4(
+    words: Nvfp4Words,
+    *,
+    device: str | torch.device = "cuda",
+) -> torch.Tensor:
+    """Reconstruct represented values ``E2M1 * E4M3FN / d_w`` in FP32."""
+
+    target = torch.device(device)
+    rows, groups = words.natural_scales.shape
+    columns = groups * 16
+    low = (words.packed_codes.to(torch.int32) & 0xF).to(target)
+    high = (words.packed_codes.to(torch.int32) >> 4).to(target)
+    decode_table = _e2m1_decode_table().to(target)
+    codes = torch.stack((low, high), dim=2).reshape(rows, columns)
+    values = decode_table[codes.long()]
+    scale_values = (
+        words.natural_scales.to(target).view(torch.float8_e4m3fn).to(torch.float32)
+    )
+    return (
+        values.reshape(rows, groups, 16)
+        * scale_values.unsqueeze(-1)
+        / words.weight_divisor
+    ).reshape(rows, columns)
+
+
+def relative_frobenius_error(
+    original: torch.Tensor, reconstructed: torch.Tensor
+) -> float:
+    left = original.detach().cpu().double()
+    right = reconstructed.detach().cpu().double()
+    difference = left - right
+    denominator = left.norm()
+    if denominator == 0.0:
+        return 0.0 if difference.norm() == 0.0 else float("inf")
+    return (difference.norm() / denominator).item()
+
+
+def encode_nvfp4_parent(
+    weight: torch.Tensor,
+    *,
+    device: str | torch.device = "cuda",
+) -> bytes:
+    """Quantize one parent and encode its verified ``blockscale-k16-m128x4-v1`` payload."""
+
+    words = quantize_nvfp4(weight, device=device)
+    shape = tuple(weight.shape)
+    payload = encode_nvfp4(
+        words.packed_codes.cpu(),
+        words.natural_scales.cpu(),
+        struct.pack("<f", words.weight_divisor),
+        shape,
+    )
+    packed, scales, divisor = decode_nvfp4_words(payload, shape)
+    if (
+        not torch.equal(packed, words.packed_codes.cpu())
+        or not torch.equal(scales, words.natural_scales.cpu())
+        or abs(divisor.item() - words.weight_divisor) != 0.0
+    ):
+        raise RuntimeError("NVFP4 layout word verification failed")
+    return payload
+
+
+def self_test(device: str | torch.device = "cuda") -> dict[str, float]:
+    """Verify the codecs against exhaustive decode tables and known ties."""
+
+    target = torch.device(device)
+    failures: list[str] = []
+
+    decode_table = _e2m1_decode_table().to(target)
+    codes = torch.arange(16, dtype=torch.uint8, device=target)
+    signs = torch.where(codes >= 8, -1.0, 1.0)
+    magnitudes = torch.tensor(_E2M1_MAGNITUDES, device=target).repeat(2)
+    expected = signs * magnitudes
+    if not torch.allclose(decode_table, expected, atol=0, rtol=0):
+        failures.append("e2m1 decode table")
+
+    grid = torch.tensor(
+        [0.0, 0.24, 0.25, 0.26, 0.5, 0.74, 0.75, 0.76, 1.0, 1.24, 1.25, 1.26,
+         1.5, 1.74, 1.75, 1.76, 2.0, 2.49, 2.5, 2.51, 3.0, 3.49, 3.5, 3.51,
+         4.0, 4.99, 5.0, 5.01, 5.9, 6.0, 7.0, 100.0],
+        device=target,
+    )
+    expected_codes = torch.tensor(
+        [0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7],
+        dtype=torch.uint8,
+        device=target,
+    )
+    actual = e2m1_rne_codes(grid)
+    if not torch.equal(actual, expected_codes):
+        failures.append(f"e2m1 rne grid: {actual.tolist()}")
+
+    negative = e2m1_rne_codes(-grid)
+    if not torch.equal((negative & 7), expected_codes) or not bool(
+        ((negative & 8) != 0).all()
+    ):
+        failures.append("e2m1 negative sign handling")
+
+    fp8_decode = _e4m3fn_decode_table(target)
+    sample = torch.tensor(
+        [0x00, 0x01, 0x38, 0x40, 0x7E, 0x80],
+        dtype=torch.uint8,
+        device=target,
+    )
+    expected_fp8 = torch.tensor(
+        [0.0, 2.0**-9, 1.0, 2.0, 448.0, -0.0], device=target
+    )
+    if not torch.allclose(fp8_decode[sample.long()], expected_fp8, atol=0, rtol=0):
+        failures.append("e4m3fn decode table")
+
+    cast_probe = torch.tensor(
+        [0.0, 1.0, 1.29, 1.5, 448.0, 447.9, 2.0**-10, 2.0**-9],
+        device=target,
+    )
+    cast_words = cast_probe.to(torch.float8_e4m3fn).view(torch.uint8)
+    if torch.equal(
+        cast_words,
+        torch.tensor([0x00, 0x38, 0x3A, 0x3C, 0x7E, 0x7E, 0x00, 0x01],
+                     dtype=torch.uint8, device=target),
+    ) is False:
+        failures.append(f"e4m3fn cast words: {cast_words.tolist()}")
+
+    if failures:
+        raise AssertionError("nvfp4 encoder self-test failed: " + "; ".join(failures))
+    return {"checked": 1.0}
+
+
+__all__ = [
+    "ENCODER_PROFILE",
+    "Nvfp4Words",
+    "dequantize_nvfp4",
+    "encode_nvfp4_parent",
+    "e2m1_rne_codes",
+    "quantize_nvfp4",
+    "relative_frobenius_error",
+    "self_test",
+]

--- a/tools/convert/qwen3_8_27b/recipe_nvfp4full.py
+++ b/tools/convert/qwen3_8_27b/recipe_nvfp4full.py
@@ -1,0 +1,768 @@
+"""Closed multi-source recipe for the fuller Qwen3.8-27B NVFP4 artifact.
+
+Three fixed source roles:
+
+- the official BF16 base supplies every locally quantized NVFP4 parent, every
+  BF16 exception parent, all direct tensors, both W8 endpoints, and the draft
+  head, MTP, and Vision components;
+- the quantized Text source supplies the 112 MLP NVFP4 parents (layers 0..55)
+  word-for-word together with their weight and input divisors;
+- the fixed calibration JSON supplies the 135 locally measured site input
+  divisors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import struct
+from typing import Iterable
+
+import torch
+
+from tools.artifact.numeric import valid_positive_fp32_word
+from tools.convert.common.safetensors import ShardReader
+from tools.convert.qwen3_6.common import recipe as family_recipe
+
+from . import inventory_nvfp4full as inventory
+from . import nvfp4_encode
+
+
+BASE_REPOSITORY = "Qwen/Qwen3.8-27B"
+BASE_REVISION = "1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0"
+# The document-pinned revision 60e813d4dbbdc5d64cf3f5a8caf2897bedf03679 was
+# force-pushed out of the upstream repository. 7d6f8d4d72f56b92b3cdbf22f156b90e1bab0108
+# is the reachable `main` revision carrying the identical quantized allocation;
+# preflight validates that allocation structurally before anything is copied.
+QUANTIZED_REPOSITORY = "unsloth/Qwen3.8-27B-NVFP4"
+QUANTIZED_REVISION = "7d6f8d4d72f56b92b3cdbf22f156b90e1bab0108"
+LOCAL_ENCODER_PROFILE = nvfp4_encode.ENCODER_PROFILE
+
+
+@dataclass(frozen=True, slots=True)
+class RowRange:
+    begin: int
+    end: int
+
+    @property
+    def rows(self) -> int:
+        return self.end - self.begin
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixSource:
+    name: str
+    shape: tuple[int, int]
+
+    def field(self, suffix: str) -> str:
+        return f"{self.name}.{suffix}"
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixPart:
+    source: MatrixSource
+    rows: tuple[RowRange, ...]
+
+    @property
+    def output_rows(self) -> int:
+        return sum(item.rows for item in self.rows)
+
+
+@dataclass(frozen=True, slots=True)
+class SourceNvfp4WeightRecipe:
+    """NVFP4 parent whose words are copied from the quantized source."""
+
+    object_name: str
+    shape: tuple[int, int]
+    parts: tuple[MatrixPart, ...]
+    divisor_sources: tuple[MatrixSource, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class LocalNvfp4WeightRecipe:
+    """NVFP4 parent quantized from the official BF16 base at conversion time."""
+
+    object_name: str
+    shape: tuple[int, int]
+    parts: tuple[MatrixPart, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class LocalInputDivisorRecipe:
+    object_name: str
+    weight_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class SourceInputDivisorRecipe:
+    object_name: str
+    sources: tuple[MatrixSource, ...]
+    weight_names: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class Bf16WeightRecipe:
+    object_name: str
+    shape: tuple[int, int]
+    parts: tuple[MatrixPart, ...]
+
+
+def _source(name: str, n: int, k: int) -> MatrixSource:
+    return MatrixSource(name, (n, k))
+
+
+def _all(source: MatrixSource) -> MatrixPart:
+    return MatrixPart(source, (RowRange(0, source.shape[0]),))
+
+
+def _q_part(source: MatrixSource, gate: bool) -> MatrixPart:
+    begin = 256 if gate else 0
+    return MatrixPart(
+        source,
+        tuple(
+            RowRange(head * 512 + begin, head * 512 + begin + 256)
+            for head in range(24)
+        ),
+    )
+
+
+def _object_layer(object_name: str) -> int:
+    return int(object_name.split("/")[2])
+
+
+def _build_matrix_recipes() -> tuple[
+    tuple[SourceNvfp4WeightRecipe, ...],
+    tuple[LocalNvfp4WeightRecipe, ...],
+    tuple[SourceInputDivisorRecipe, ...],
+    tuple[LocalInputDivisorRecipe, ...],
+    tuple[Bf16WeightRecipe, ...],
+    tuple[tuple[MatrixSource, ...], ...],
+]:
+    source_weights: list[SourceNvfp4WeightRecipe] = []
+    local_weights: list[LocalNvfp4WeightRecipe] = []
+    source_divisors: list[SourceInputDivisorRecipe] = []
+    local_divisors: list[LocalInputDivisorRecipe] = []
+    bf16_weights: list[Bf16WeightRecipe] = []
+    divisor_groups: list[tuple[MatrixSource, ...]] = []
+
+    for layer in range(64):
+        source_prefix = f"model.language_model.layers.{layer}."
+        object_prefix = f"text/layers/{layer}/"
+        if layer in inventory.FULL_ATTENTION_LAYERS:
+            query = _source(source_prefix + "self_attn.q_proj", 12288, 5120)
+            key = _source(source_prefix + "self_attn.k_proj", 1024, 5120)
+            value = _source(source_prefix + "self_attn.v_proj", 1024, 5120)
+            output = _source(source_prefix + "self_attn.o_proj", 5120, 6144)
+            qkgv_parts = (
+                _q_part(query, False),
+                _all(key),
+                _q_part(query, True),
+                _all(value),
+            )
+            qkgv_name = object_prefix + "attention/query_key_gate_value"
+            if layer in inventory.EARLY_ATTENTION_INPUT_LAYERS:
+                bf16_weights.append(
+                    Bf16WeightRecipe(qkgv_name, (14336, 5120), qkgv_parts)
+                )
+            else:
+                local_weights.append(
+                    LocalNvfp4WeightRecipe(qkgv_name, (14336, 5120), qkgv_parts)
+                )
+                local_divisors.append(
+                    LocalInputDivisorRecipe(
+                        object_prefix
+                        + "attention/input_projection/input_scale_divisor",
+                        qkgv_name,
+                    )
+                )
+            output_name = object_prefix + "attention/output"
+            if layer in inventory.BF16_ATTENTION_OUTPUT_LAYERS:
+                bf16_weights.append(
+                    Bf16WeightRecipe(output_name, output.shape, (_all(output),))
+                )
+            else:
+                local_weights.append(
+                    LocalNvfp4WeightRecipe(output_name, output.shape, (_all(output),))
+                )
+                local_divisors.append(
+                    LocalInputDivisorRecipe(
+                        object_prefix
+                        + "attention/output_projection/input_scale_divisor",
+                        output_name,
+                    )
+                )
+        else:
+            query_key_value = _source(
+                source_prefix + "linear_attn.in_proj_qkv", 10240, 5120
+            )
+            z = _source(source_prefix + "linear_attn.in_proj_z", 6144, 5120)
+            output = _source(source_prefix + "linear_attn.out_proj", 5120, 6144)
+            qkvz_name = object_prefix + "gdn/query_key_value_z"
+            qkvz_parts = (_all(query_key_value), _all(z))
+            local_weights.append(
+                LocalNvfp4WeightRecipe(qkvz_name, (16384, 5120), qkvz_parts)
+            )
+            local_divisors.append(
+                LocalInputDivisorRecipe(
+                    object_prefix + "gdn/input_projection/input_scale_divisor",
+                    qkvz_name,
+                )
+            )
+            output_name = object_prefix + "gdn/output"
+            if layer in inventory.BF16_GDN_OUTPUT_LAYERS:
+                bf16_weights.append(
+                    Bf16WeightRecipe(output_name, output.shape, (_all(output),))
+                )
+            else:
+                local_weights.append(
+                    LocalNvfp4WeightRecipe(output_name, output.shape, (_all(output),))
+                )
+                local_divisors.append(
+                    LocalInputDivisorRecipe(
+                        object_prefix
+                        + "gdn/output_projection/input_scale_divisor",
+                        output_name,
+                    )
+                )
+
+        gate = _source(source_prefix + "mlp.gate_proj", 17408, 5120)
+        up = _source(source_prefix + "mlp.up_proj", 17408, 5120)
+        down = _source(source_prefix + "mlp.down_proj", 5120, 17408)
+        gate_up_name = object_prefix + "mlp/gate_up"
+        down_name = object_prefix + "mlp/down"
+        if layer in inventory.SOURCE_NVFP4_MLP_LAYERS:
+            gate_up_sources = (gate, up)
+            divisor_groups.append(gate_up_sources)
+            source_weights.extend(
+                (
+                    SourceNvfp4WeightRecipe(
+                        gate_up_name,
+                        (34816, 5120),
+                        (_all(gate), _all(up)),
+                        gate_up_sources,
+                    ),
+                    SourceNvfp4WeightRecipe(
+                        down_name, down.shape, (_all(down),), (down,)
+                    ),
+                )
+            )
+            source_divisors.extend(
+                (
+                    SourceInputDivisorRecipe(
+                        object_prefix
+                        + "mlp/gate_up_projection/input_scale_divisor",
+                        gate_up_sources,
+                        (gate_up_name,),
+                    ),
+                    SourceInputDivisorRecipe(
+                        object_prefix
+                        + "mlp/down_projection/input_scale_divisor",
+                        (down,),
+                        (down_name,),
+                    ),
+                )
+            )
+        else:
+            local_weights.extend(
+                (
+                    LocalNvfp4WeightRecipe(
+                        gate_up_name, (34816, 5120), (_all(gate), _all(up))
+                    ),
+                    LocalNvfp4WeightRecipe(
+                        down_name, down.shape, (_all(down),)
+                    ),
+                )
+            )
+            local_divisors.extend(
+                (
+                    LocalInputDivisorRecipe(
+                        object_prefix
+                        + "mlp/gate_up_projection/input_scale_divisor",
+                        gate_up_name,
+                    ),
+                    LocalInputDivisorRecipe(
+                        object_prefix
+                        + "mlp/down_projection/input_scale_divisor",
+                        down_name,
+                    ),
+                )
+            )
+
+    return (
+        tuple(source_weights),
+        tuple(local_weights),
+        tuple(source_divisors),
+        tuple(local_divisors),
+        tuple(bf16_weights),
+        tuple(divisor_groups),
+    )
+
+
+def _build_base_direct_recipes() -> tuple[family_recipe.TensorRecipe, ...]:
+    recipes: list[family_recipe.TensorRecipe] = []
+    for layer in range(64):
+        source_prefix = f"model.language_model.layers.{layer}."
+        object_prefix = f"text/layers/{layer}/"
+        recipes.append(
+            family_recipe.TensorRecipe(
+                object_prefix + "input_norm",
+                family_recipe.source(
+                    source_prefix + "input_layernorm.weight", (5120,)
+                ),
+            )
+        )
+        if layer in inventory.FULL_ATTENTION_LAYERS:
+            recipes.extend(
+                (
+                    family_recipe.TensorRecipe(
+                        object_prefix + "attention/query_norm",
+                        family_recipe.source(
+                            source_prefix + "self_attn.q_norm.weight", (256,)
+                        ),
+                    ),
+                    family_recipe.TensorRecipe(
+                        object_prefix + "attention/key_norm",
+                        family_recipe.source(
+                            source_prefix + "self_attn.k_norm.weight", (256,)
+                        ),
+                    ),
+                )
+            )
+        else:
+            convolution = family_recipe.source(
+                source_prefix + "linear_attn.conv1d.weight", (10240, 1, 4)
+            )
+            recipes.extend(
+                (
+                    family_recipe.TensorRecipe(
+                        object_prefix + "gdn/a_log",
+                        family_recipe.Cast(
+                            family_recipe.source(
+                                source_prefix + "linear_attn.A_log", (48,)
+                            ),
+                            inventory.FP32,
+                        ),
+                    ),
+                    family_recipe.TensorRecipe(
+                        object_prefix + "gdn/dt_bias",
+                        family_recipe.Cast(
+                            family_recipe.source(
+                                source_prefix + "linear_attn.dt_bias", (48,)
+                            ),
+                            inventory.FP32,
+                        ),
+                    ),
+                    family_recipe.TensorRecipe(
+                        object_prefix + "gdn/convolution",
+                        family_recipe.Transpose(
+                            family_recipe.Reshape(
+                                family_recipe.Slice(convolution, 1, 0, 1),
+                                (10240, 4),
+                            ),
+                            (1, 0),
+                        ),
+                    ),
+                    family_recipe.TensorRecipe(
+                        object_prefix + "gdn/a_b_projection",
+                        family_recipe.Concat(
+                            (
+                                family_recipe.source(
+                                    source_prefix
+                                    + "linear_attn.in_proj_a.weight",
+                                    (48, 5120),
+                                ),
+                                family_recipe.source(
+                                    source_prefix
+                                    + "linear_attn.in_proj_b.weight",
+                                    (48, 5120),
+                                ),
+                            ),
+                            0,
+                        ),
+                    ),
+                    family_recipe.TensorRecipe(
+                        object_prefix + "gdn/norm",
+                        family_recipe.source(
+                            source_prefix + "linear_attn.norm.weight", (128,)
+                        ),
+                    ),
+                )
+            )
+        recipes.append(
+            family_recipe.TensorRecipe(
+                object_prefix + "post_attention_norm",
+                family_recipe.source(
+                    source_prefix + "post_attention_layernorm.weight", (5120,)
+                ),
+            )
+        )
+    recipes.append(
+        family_recipe.TensorRecipe(
+            "text/final_norm",
+            family_recipe.source("model.language_model.norm.weight", (5120,)),
+        )
+    )
+    return tuple(recipes)
+
+
+(
+    SOURCE_NVFP4_WEIGHT_RECIPES,
+    LOCAL_NVFP4_WEIGHT_RECIPES,
+    SOURCE_INPUT_DIVISOR_RECIPES,
+    LOCAL_INPUT_DIVISOR_RECIPES,
+    BF16_WEIGHT_RECIPES,
+    WEIGHT_DIVISOR_GROUPS,
+) = _build_matrix_recipes()
+
+SOURCE_NVFP4_WEIGHTS_BY_NAME = {
+    item.object_name: item for item in SOURCE_NVFP4_WEIGHT_RECIPES
+}
+LOCAL_NVFP4_WEIGHTS_BY_NAME = {
+    item.object_name: item for item in LOCAL_NVFP4_WEIGHT_RECIPES
+}
+SOURCE_INPUT_DIVISORS_BY_NAME = {
+    item.object_name: item for item in SOURCE_INPUT_DIVISOR_RECIPES
+}
+LOCAL_INPUT_DIVISORS_BY_NAME = {
+    item.object_name: item for item in LOCAL_INPUT_DIVISOR_RECIPES
+}
+BF16_WEIGHTS_BY_NAME = {item.object_name: item for item in BF16_WEIGHT_RECIPES}
+
+NVFP4_SOURCES = tuple(
+    dict.fromkeys(
+        part.source for recipe in SOURCE_NVFP4_WEIGHT_RECIPES for part in recipe.parts
+    )
+)
+
+BASE_DIRECT_RECIPES = _build_base_direct_recipes()
+BASE_DIRECT_BY_NAME = {item.object_name: item for item in BASE_DIRECT_RECIPES}
+BASE_DIRECT_SPECS = tuple(
+    spec
+    for spec in inventory.TEXT_CORE_TENSOR_SPECS
+    if spec.name in BASE_DIRECT_BY_NAME
+)
+
+# Endpoints, draft head, MTP, and Vision reuse the registered official-source
+# recipe objects; they are quantized from the BF16 base with the canonical
+# grouped-int encoder.
+from . import recipe_nvfp4 as registered  # noqa: E402
+
+_OFFICIAL_RECIPES_BY_NAME = dict(registered.OFFICIAL_RECIPES_BY_NAME)
+_OFFICIAL_RECIPES_BY_NAME["text/output_head"] = family_recipe.TensorRecipe(
+    "text/output_head",
+    family_recipe.source("lm_head.weight", (248320, 5120)),
+)
+OFFICIAL_RECIPES_BY_NAME = _OFFICIAL_RECIPES_BY_NAME
+OFFICIAL_TENSOR_SPECS = tuple(
+    spec
+    for spec in inventory.TENSOR_SPECS
+    if spec.name in OFFICIAL_RECIPES_BY_NAME
+)
+
+
+def _validate_parts(
+    object_name: str, shape: tuple[int, int], parts: tuple[MatrixPart, ...]
+) -> None:
+    rows = sum(part.output_rows for part in parts)
+    if not parts or (rows, parts[0].source.shape[1]) != shape:
+        raise ValueError(f"{object_name}: invalid fused row geometry")
+    if any(part.source.shape[1] != shape[1] for part in parts):
+        raise ValueError(f"{object_name}: incompatible source K")
+
+
+def validate_recipe() -> None:
+    family_recipe.validate_recipe_coverage(BASE_DIRECT_RECIPES, BASE_DIRECT_SPECS)
+    family_recipe.validate_recipe_coverage(
+        tuple(OFFICIAL_RECIPES_BY_NAME[spec.name] for spec in OFFICIAL_TENSOR_SPECS),
+        OFFICIAL_TENSOR_SPECS,
+    )
+    if (
+        len(SOURCE_NVFP4_WEIGHT_RECIPES),
+        len(LOCAL_NVFP4_WEIGHT_RECIPES),
+        len(SOURCE_INPUT_DIVISOR_RECIPES),
+        len(LOCAL_INPUT_DIVISOR_RECIPES),
+        len(BF16_WEIGHT_RECIPES),
+        len(WEIGHT_DIVISOR_GROUPS),
+        len(NVFP4_SOURCES),
+        len(BASE_DIRECT_RECIPES),
+    ) != (112, 135, 112, 135, 9, 56, 168, 401):
+        raise ValueError("Qwen3.8 nvfp4full source recipe is incomplete")
+
+    inventory_nvfp4_names = {spec.name for spec in inventory.NVFP4_TENSOR_SPECS}
+    if set(SOURCE_NVFP4_WEIGHTS_BY_NAME) | set(LOCAL_NVFP4_WEIGHTS_BY_NAME) != inventory_nvfp4_names:
+        raise ValueError("NVFP4 weight routes do not cover the NVFP4 parents")
+    if set(SOURCE_NVFP4_WEIGHTS_BY_NAME) & set(LOCAL_NVFP4_WEIGHTS_BY_NAME):
+        raise ValueError("an NVFP4 parent has two materialization routes")
+    if set(SOURCE_NVFP4_WEIGHTS_BY_NAME) != {
+        spec.name for spec in inventory.SOURCE_NVFP4_WEIGHT_SPECS
+    }:
+        raise ValueError("source NVFP4 routes do not match the inventory selection")
+
+    divisor_names = {spec.name for spec in inventory.INPUT_SCALE_DIVISOR_SPECS}
+    if set(SOURCE_INPUT_DIVISORS_BY_NAME) | set(LOCAL_INPUT_DIVISORS_BY_NAME) != divisor_names:
+        raise ValueError("input-divisor routes do not cover the divisor sites")
+    if set(SOURCE_INPUT_DIVISORS_BY_NAME) & set(LOCAL_INPUT_DIVISORS_BY_NAME):
+        raise ValueError("an input divisor has two materialization routes")
+
+    bound_source = {
+        name for site in SOURCE_INPUT_DIVISOR_RECIPES for name in site.weight_names
+    }
+    if bound_source != set(SOURCE_NVFP4_WEIGHTS_BY_NAME):
+        raise ValueError("source input-divisor sites do not bind their parents once")
+    bound_local = {site.weight_name for site in LOCAL_INPUT_DIVISOR_RECIPES}
+    if bound_local != set(LOCAL_NVFP4_WEIGHTS_BY_NAME):
+        raise ValueError("local input-divisor sites do not bind their parents once")
+
+    if set(BF16_WEIGHTS_BY_NAME) != {spec.name for spec in inventory.BF16_EXCEPTION_SPECS}:
+        raise ValueError("BF16 exception routes do not match the inventory")
+
+    ownership = (
+        set(SOURCE_NVFP4_WEIGHTS_BY_NAME),
+        set(LOCAL_NVFP4_WEIGHTS_BY_NAME),
+        set(SOURCE_INPUT_DIVISORS_BY_NAME),
+        set(LOCAL_INPUT_DIVISORS_BY_NAME),
+        set(BF16_WEIGHTS_BY_NAME),
+        set(BASE_DIRECT_BY_NAME),
+        set(OFFICIAL_RECIPES_BY_NAME),
+    )
+    names: set[str] = set()
+    for route in ownership:
+        if names & route:
+            raise ValueError("more than one source route owns an artifact tensor")
+        names.update(route)
+    if names != {spec.name for spec in inventory.TENSOR_SPECS}:
+        missing = {spec.name for spec in inventory.TENSOR_SPECS} - names
+        extra = names - {spec.name for spec in inventory.TENSOR_SPECS}
+        raise ValueError(f"source routes do not cover the inventory: {sorted(missing)[:2]} {sorted(extra)[:2]}")
+
+    for recipe in SOURCE_NVFP4_WEIGHT_RECIPES:
+        _validate_parts(recipe.object_name, recipe.shape, recipe.parts)
+    for recipe in LOCAL_NVFP4_WEIGHT_RECIPES:
+        _validate_parts(recipe.object_name, recipe.shape, recipe.parts)
+    for recipe in BF16_WEIGHT_RECIPES:
+        _validate_parts(recipe.object_name, recipe.shape, recipe.parts)
+
+
+def source_field_requirements() -> dict[str, tuple[tuple[int, ...], str]]:
+    requirements: dict[str, tuple[tuple[int, ...], str]] = {}
+    for source in NVFP4_SOURCES:
+        n, k = source.shape
+        for suffix, shape, dtype in (
+            ("weight_packed", (n, k // 2), "U8"),
+            ("weight_scale", (n, k // 16), "F8_E4M3"),
+            ("weight_global_scale", (1,), "F32"),
+            ("input_global_scale", (1,), "F32"),
+        ):
+            name = source.field(suffix)
+            previous = requirements.setdefault(name, (shape, dtype))
+            if previous != (shape, dtype):
+                raise ValueError(f"inconsistent source declaration for {name}")
+    return requirements
+
+
+def preflight_quantized_metadata(reader: ShardReader) -> dict[str, int]:
+    """Validate that the quantized source carries exactly the MLP allocation."""
+
+    requirements = source_field_requirements()
+    missing = set(requirements).difference(reader.names)
+    if missing:
+        raise ValueError(f"quantized source is missing {sorted(missing)[0]}")
+    metadata = reader.metadata(reader.names)
+    dtype_counts: dict[str, int] = {}
+    for name, (shape, dtype) in requirements.items():
+        actual = metadata[name]
+        if actual.shape != shape or actual.dtype != dtype:
+            raise ValueError(
+                f"{name}: source signature {(actual.shape, actual.dtype)} "
+                f"!= {(shape, dtype)}"
+            )
+        dtype_counts[dtype] = dtype_counts.get(dtype, 0) + 1
+    if dtype_counts != {"U8": 168, "F8_E4M3": 168, "F32": 336}:
+        raise ValueError(f"unexpected quantized-source allocation: {dtype_counts}")
+    # Every non-MLP linear must exist as a row-scaled FP8 field, proving the
+    # checkpoint is the registered mixed-precision allocation.
+    fp8_fields = {
+        name
+        for name, item in metadata.items()
+        if item.dtype == "F8_E4M3" and name.endswith(".weight")
+    }
+    expected_fp8 = 233
+    if len(fp8_fields) != expected_fp8:
+        raise ValueError(
+            f"quantized source FP8 allocation has {len(fp8_fields)} matrices, "
+            f"expected {expected_fp8}"
+        )
+    return dtype_counts
+
+
+def _word(tensor: torch.Tensor, name: str) -> int:
+    if tensor.dtype != torch.float32 or tensor.numel() != 1:
+        raise ValueError(f"{name}: divisor must be FP32[1]")
+    word = int(tensor.detach().contiguous().cpu().view(torch.int32).item())
+    word &= 0xFFFFFFFF
+    if not valid_positive_fp32_word(word):
+        raise ValueError(f"{name}: divisor must be finite and positive")
+    return word
+
+
+def _same_divisor(
+    reader: ShardReader,
+    sources: Iterable[MatrixSource],
+    suffix: str,
+) -> int:
+    items = tuple(sources)
+    words = tuple(
+        _word(reader.get(source.field(suffix)), source.field(suffix))
+        for source in items
+    )
+    if len(set(words)) != 1:
+        raise ValueError(f"{items[0].name}: fused {suffix} words differ")
+    return words[0]
+
+
+def _select_rows(tensor: torch.Tensor, part: MatrixPart) -> torch.Tensor:
+    pieces = [
+        tensor.narrow(0, row_range.begin, row_range.rows) for row_range in part.rows
+    ]
+    if len(pieces) == 1:
+        return pieces[0]
+    return torch.cat(pieces, dim=0)
+
+
+def materialize_bf16_parent(
+    parts: tuple[MatrixPart, ...], reader: ShardReader
+) -> torch.Tensor:
+    pieces = [
+        _select_rows(reader.get(part.source.field("weight")), part) for part in parts
+    ]
+    matrix = pieces[0].contiguous() if len(pieces) == 1 else torch.cat(pieces, dim=0)
+    return matrix
+
+
+def materialize_source_nvfp4_weight(
+    recipe: SourceNvfp4WeightRecipe,
+    reader: ShardReader,
+) -> tuple[torch.Tensor, torch.Tensor, bytes]:
+    packed_parts: list[torch.Tensor] = []
+    scale_parts: list[torch.Tensor] = []
+    source_words: dict[MatrixSource, tuple[torch.Tensor, torch.Tensor]] = {}
+    for part in recipe.parts:
+        words = source_words.get(part.source)
+        if words is None:
+            n, k = part.source.shape
+            source_packed = reader.get(part.source.field("weight_packed"))
+            source_scales = reader.get(part.source.field("weight_scale"))
+            if (
+                source_packed.dtype != torch.uint8
+                or tuple(source_packed.shape) != (n, k // 2)
+                or source_scales.dtype != torch.float8_e4m3fn
+                or tuple(source_scales.shape) != (n, k // 16)
+            ):
+                raise ValueError(
+                    f"{part.source.name}: materialized NVFP4 source signature mismatch"
+                )
+            words = (source_packed, source_scales.view(torch.uint8))
+            source_words[part.source] = words
+        packed_parts.append(_select_rows(words[0], part))
+        scale_parts.append(_select_rows(words[1], part))
+    packed = (
+        packed_parts[0].contiguous()
+        if len(packed_parts) == 1
+        else torch.cat(packed_parts, dim=0)
+    )
+    scales = (
+        scale_parts[0].contiguous()
+        if len(scale_parts) == 1
+        else torch.cat(scale_parts, dim=0)
+    )
+    divisor = _same_divisor(reader, recipe.divisor_sources, "weight_global_scale")
+    if tuple(packed.shape) != (recipe.shape[0], recipe.shape[1] // 2) or tuple(
+        scales.shape
+    ) != (recipe.shape[0], recipe.shape[1] // 16):
+        raise ValueError(
+            f"{recipe.object_name}: materialized NVFP4 shape mismatch"
+        )
+    return packed, scales, struct.pack("<I", divisor)
+
+
+def materialize_source_input_divisor(
+    recipe: SourceInputDivisorRecipe, reader: ShardReader
+) -> torch.Tensor:
+    word = _same_divisor(reader, recipe.sources, "input_global_scale")
+    return torch.frombuffer(
+        bytearray(struct.pack("<I", word)), dtype=torch.float32
+    ).reshape(())
+
+
+class LocalDivisorTable:
+    """The fixed calibration result behind every locally measured d_x site."""
+
+    def __init__(self, calibration_path: str | Path):
+        document = json.loads(Path(calibration_path).read_text(encoding="utf-8"))
+        measured = document.get("measured_sites")
+        if not isinstance(measured, dict):
+            raise ValueError("calibration document has no measured_sites table")
+        expected = set(LOCAL_INPUT_DIVISORS_BY_NAME)
+        if set(measured) != expected:
+            missing = sorted(expected - set(measured))[:2]
+            extra = sorted(set(measured) - expected)[:2]
+            raise ValueError(f"calibration site set mismatch: {missing} {extra}")
+        self._values: dict[str, float] = {}
+        for name, entry in measured.items():
+            value = entry["input_scale_divisor"]
+            word = struct.unpack("<I", struct.pack("<f", float(value)))[0]
+            if not valid_positive_fp32_word(word):
+                raise ValueError(f"{name}: calibrated input divisor is invalid")
+            self._values[name] = float(value)
+        self.provenance = {
+            key: document.get(key)
+            for key in (
+                "encoder_profile",
+                "divisor_formula",
+                "model_path",
+                "quantized_model_path",
+                "corpus_documents",
+                "corpus_tokens",
+            )
+        }
+
+    def value(self, object_name: str) -> torch.Tensor:
+        value = self._values[object_name]
+        return torch.frombuffer(
+            bytearray(struct.pack("<f", value)), dtype=torch.float32
+        ).reshape(())
+
+
+validate_recipe()
+
+
+__all__ = [
+    "BASE_DIRECT_BY_NAME",
+    "BASE_DIRECT_RECIPES",
+    "BASE_DIRECT_SPECS",
+    "BASE_REPOSITORY",
+    "BASE_REVISION",
+    "BF16_WEIGHTS_BY_NAME",
+    "BF16_WEIGHT_RECIPES",
+    "LOCAL_ENCODER_PROFILE",
+    "LOCAL_INPUT_DIVISORS_BY_NAME",
+    "LOCAL_INPUT_DIVISOR_RECIPES",
+    "LOCAL_NVFP4_WEIGHTS_BY_NAME",
+    "LOCAL_NVFP4_WEIGHT_RECIPES",
+    "LocalDivisorTable",
+    "NVFP4_SOURCES",
+    "OFFICIAL_RECIPES_BY_NAME",
+    "OFFICIAL_TENSOR_SPECS",
+    "QUANTIZED_REPOSITORY",
+    "QUANTIZED_REVISION",
+    "SOURCE_INPUT_DIVISORS_BY_NAME",
+    "SOURCE_INPUT_DIVISOR_RECIPES",
+    "SOURCE_NVFP4_WEIGHTS_BY_NAME",
+    "SOURCE_NVFP4_WEIGHT_RECIPES",
+    "materialize_bf16_parent",
+    "materialize_source_input_divisor",
+    "materialize_source_nvfp4_weight",
+    "preflight_quantized_metadata",
+    "validate_recipe",
+]

--- a/tools/convert/qwen3_8_27b/split_quantized_shards.py
+++ b/tools/convert/qwen3_8_27b/split_quantized_shards.py
@@ -1,0 +1,129 @@
+"""Split an oversized quantized-source shard into ~2 GiB shards.
+
+The upstream quantized checkpoint stores all Text tensors in one shard larger
+than the host will reliably memory-map while other model shards are resident.
+This mechanical repack copies every tensor byte-for-byte into bounded shards
+and rewrites ``model.safetensors.index.json``; it changes no values, names,
+dtypes, or shapes. The copy path parses the safetensors header and reads tensor
+spans with plain file reads, so it never memory-maps the oversized source.
+
+Canonical invocation::
+
+    python3 -m tools.convert.qwen3_8_27b.split_quantized_shards \
+      --model /path/to/Qwen3.8-27B-NVFP4 \
+      --target-shard-bytes 2147483648
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+import json
+from pathlib import Path
+import struct
+
+import torch
+from safetensors.torch import save_file
+
+
+TARGET_SHARD_BYTES = 2 * 1024 * 1024 * 1024
+OUTPUT_SHARD_PREFIX = "model-split"
+
+_DTYPES = {
+    "BF16": torch.bfloat16,
+    "F32": torch.float32,
+    "F8_E4M3": torch.float8_e4m3fn,
+    "U8": torch.uint8,
+    "I64": torch.int64,
+    "I32": torch.int32,
+}
+
+
+def _read_header(path: Path) -> tuple[dict, int]:
+    with path.open("rb") as handle:
+        length = struct.unpack("<Q", handle.read(8))[0]
+        header = json.loads(handle.read(length))
+    return header, 8 + length
+
+
+def _read_tensor(path: Path, base: int, entry: dict) -> torch.Tensor:
+    begin, end = entry["data_offsets"]
+    dtype = _DTYPES[entry["dtype"]]
+    element_size = torch.empty((), dtype=dtype).element_size()
+    count = (end - begin) // max(1, element_size)
+    with path.open("rb") as handle:
+        handle.seek(base + begin)
+        raw = handle.read(end - begin)
+    shape = entry.get("shape", [])
+    if not shape:
+        return torch.frombuffer(bytearray(raw), dtype=dtype).reshape(())
+    elements = 1
+    for dim in shape:
+        elements *= dim
+    return torch.frombuffer(bytearray(raw), dtype=dtype).reshape(shape)
+
+
+def split_shards(model_dir: str | Path, target_bytes: int = TARGET_SHARD_BYTES) -> None:
+    base = Path(model_dir)
+    index_path = base / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text())
+    weight_map: dict[str, str] = index["weight_map"]
+
+    by_shard: dict[str, list[str]] = defaultdict(list)
+    for name, shard in weight_map.items():
+        by_shard[shard].append(name)
+
+    new_map: dict[str, str] = {}
+    part = 0
+    current: dict[str, torch.Tensor] = {}
+    current_bytes = 0
+
+    def flush(total_hint: int | None = None) -> None:
+        nonlocal part, current, current_bytes
+        if not current:
+            return
+        part += 1
+        total = total_hint if total_hint is not None else part
+        name = f"{OUTPUT_SHARD_PREFIX}-{part:05d}-of-{total:05d}.safetensors"
+        save_file(current, str(base / name))
+        for tensor_name in current:
+            new_map[tensor_name] = name
+        current = {}
+        current_bytes = 0
+
+    for shard in sorted(by_shard):
+        if shard.startswith(OUTPUT_SHARD_PREFIX):
+            continue
+        header, data_base = _read_header(base / shard)
+        for name in by_shard[shard]:
+            entry = header[name]
+            begin, end = entry["data_offsets"]
+            size = end - begin
+            if current_bytes and current_bytes + size > target_bytes:
+                flush()
+            current[name] = _read_tensor(base / shard, data_base, entry)
+            current_bytes += size
+    pending = current
+    total_estimate = part + (1 if pending else 0)
+    flush(total_hint=total_estimate)
+    if part != total_estimate:
+        # The final flush disagreed with the estimate; rewrite only its name.
+        raise RuntimeError("final shard count estimate failed; rerun the split")
+    final_index = {
+        "metadata": index.get("metadata", {}),
+        "weight_map": new_map,
+    }
+    index_path.write_text(json.dumps(final_index, indent=2))
+    print(f"split {len(new_map)} tensors into {total} shards")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--target-shard-bytes", type=int, default=TARGET_SHARD_BYTES)
+    arguments = parser.parse_args()
+    split_shards(arguments.model, arguments.target_shard_bytes)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/convert/qwen3_8_27b/verify_nvfp4full.py
+++ b/tools/convert/qwen3_8_27b/verify_nvfp4full.py
@@ -1,0 +1,349 @@
+"""Verify the fuller Qwen3.8-27B NVFP4 artifact against its three source roles."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+from typing import Sequence
+
+from safetensors import safe_open
+import torch
+
+from tools.artifact.container import (
+    Artifact,
+    ArtifactIdentity,
+    ResourceObject,
+    TensorObject,
+    object_alignment,
+)
+from tools.artifact.layouts import (
+    align_up,
+    decode_direct,
+    decode_nvfp4_words,
+    encoded_size,
+)
+from tools.artifact.numeric import valid_positive_fp32_word
+from tools.convert.common.safetensors import ShardReader
+from tools.convert.qwen3_6.common import recipe as family_recipe
+
+from . import convert_nvfp4full as convert
+from . import inventory_nvfp4full as inventory
+from . import nvfp4_encode
+from . import recipe_nvfp4full as recipe
+from tools.convert.qwen3_6_27b import verify as base_verify
+
+
+class VerificationError(ValueError):
+    """The artifact does not satisfy the registered nvfp4full contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationSummary:
+    objects: int
+    tensors: int
+    resources: int
+    w8_endpoint_weights: int
+    w8_endpoint_rows: int
+    w8_endpoint_groups: int
+    source_nvfp4_weights: int
+    local_nvfp4_weights: int
+    local_nvfp4_max_relative_error: float
+    bf16_exception_matrices: int
+    input_divisors_source: int
+    input_divisors_local: int
+    payload_bytes: int
+
+
+def _error(message: str) -> None:
+    raise VerificationError(message)
+
+
+def validate_structure(artifact: Artifact) -> int:
+    expected_identity = ArtifactIdentity(inventory.MODEL_ID, inventory.WEIGHTS_ID)
+    if artifact.identity != expected_identity:
+        _error(
+            f"artifact identity is {artifact.identity!r}, expected "
+            f"{expected_identity!r}"
+        )
+    if len(artifact.objects) != len(inventory.OBJECT_SPECS):
+        _error(
+            f"artifact has {len(artifact.objects)} objects, "
+            f"expected {len(inventory.OBJECT_SPECS)}"
+        )
+    cursor = 0
+    formats: Counter[str] = Counter()
+    layouts: Counter[str] = Counter()
+    for position, (actual, expected) in enumerate(
+        zip(artifact.objects, inventory.OBJECT_SPECS)
+    ):
+        if actual.name != expected.name:
+            _error(
+                f"object {position} is {actual.name!r}, expected {expected.name!r}"
+            )
+        expected_offset = align_up(cursor, object_alignment(actual))
+        if actual.offset != expected_offset:
+            _error(f"{actual.name}: offset {actual.offset}, expected {expected_offset}")
+        if isinstance(expected, inventory.TensorSpec):
+            if not isinstance(actual, TensorObject):
+                _error(f"{actual.name}: expected tensor descriptor")
+            signature = (actual.shape, actual.format, actual.layout)
+            registered = (expected.shape, expected.format, expected.layout)
+            if signature != registered:
+                _error(f"{actual.name}: signature {signature} != {registered}")
+            if actual.bytes != encoded_size(actual.layout, actual.format, actual.shape):
+                _error(f"{actual.name}: encoded byte count is invalid")
+            formats[actual.format] += 1
+            layouts[actual.layout] += 1
+        else:
+            if not isinstance(actual, ResourceObject):
+                _error(f"{actual.name}: expected resource descriptor")
+            if actual.encoding != expected.encoding:
+                _error(f"{actual.name}: resource encoding is invalid")
+        cursor = actual.offset + actual.bytes
+    if dict(formats) != inventory.FORMAT_COUNTS:
+        _error(f"numeric-format counts are {dict(formats)}")
+    if dict(layouts) != inventory.LAYOUT_COUNTS:
+        _error(f"layout counts are {dict(layouts)}")
+    payload_bytes = artifact.file_bytes - artifact.payload_offset
+    if cursor != payload_bytes:
+        _error(f"payload ends at {cursor}, file contains {payload_bytes} bytes")
+    return payload_bytes
+
+
+def _verify_resources(artifact: Artifact, base_dir: Path) -> None:
+    for spec in inventory.RESOURCE_SPECS:
+        obj = artifact.find(spec.name)
+        if not isinstance(obj, ResourceObject):
+            _error(f"{spec.name}: expected resource")
+        source = (base_dir / spec.name.removeprefix("frontend/")).read_bytes()
+        if bytes(artifact.payload(obj)) != source:
+            _error(f"{spec.name}: resource payload differs from base source")
+
+
+W8_ENDPOINT_SPECS = tuple(
+    spec
+    for spec in inventory.TENSOR_SPECS
+    if spec.name in ("text/token_embedding", "text/output_head")
+)
+
+
+def _source_rows(
+    reader: ShardReader,
+    source: family_recipe.SourceTensor,
+    rows: Sequence[int],
+) -> torch.Tensor:
+    shard = reader.weight_map[source.name]
+    with safe_open(
+        str(reader.model_dir / shard),
+        framework="pt",
+        device="cpu",
+    ) as handle:
+        tensor_slice = handle.get_slice(source.name)
+        pieces = [tensor_slice[row : row + 1] for row in rows]
+    return torch.cat(pieces, dim=0)
+
+
+def _verify_w8_endpoints(
+    artifact: Artifact,
+    reader: ShardReader,
+) -> tuple[int, int]:
+    verified_rows = 0
+    verified_groups = 0
+    for spec in W8_ENDPOINT_SPECS:
+        obj = artifact.find(spec.name)
+        if not isinstance(obj, TensorObject):
+            _error(f"{spec.name}: expected tensor")
+        expression = recipe.OFFICIAL_RECIPES_BY_NAME[spec.name].expression
+        if not isinstance(expression, family_recipe.SourceTensor):
+            _error(f"{spec.name}: endpoint source must be one direct BF16 matrix")
+        rows = tuple(dict.fromkeys((0, spec.shape[0] // 2, spec.shape[0] - 1)))
+        source_rows = _source_rows(reader, expression, rows)
+        try:
+            verified_groups += base_verify.verify_quantized_rows(
+                artifact.payload(obj),
+                obj.format,
+                obj.shape,
+                rows,
+                source_rows,
+            )
+        except base_verify.VerificationError as error:
+            _error(f"{spec.name}: {error}")
+        verified_rows += len(rows)
+    return verified_rows, verified_groups
+
+
+def _verify_source_nvfp4_weights(
+    artifact: Artifact,
+    reader: ShardReader,
+) -> None:
+    for selected in recipe.SOURCE_NVFP4_WEIGHT_RECIPES:
+        obj = artifact.find(selected.object_name)
+        if not isinstance(obj, TensorObject):
+            _error(f"{selected.object_name}: expected tensor")
+        packed, scales, divisor = recipe.materialize_source_nvfp4_weight(
+            selected, reader
+        )
+        stored_packed, stored_scales, stored_divisor = decode_nvfp4_words(
+            artifact.payload(obj), obj.shape
+        )
+        if not torch.equal(stored_packed, packed):
+            _error(f"{obj.name}: packed E2M1 words differ from source")
+        if not torch.equal(stored_scales, scales):
+            _error(f"{obj.name}: E4M3FN scale words differ from source")
+        if bytes(stored_divisor.reshape(1).view(torch.uint8).numpy()) != divisor:
+            _error(f"{obj.name}: weight divisor differs from source")
+
+
+def _verify_local_nvfp4_weights(
+    artifact: Artifact,
+    reader: ShardReader,
+    device: torch.device,
+) -> float:
+    max_error = 0.0
+    for selected in recipe.LOCAL_NVFP4_WEIGHT_RECIPES:
+        obj = artifact.find(selected.object_name)
+        if not isinstance(obj, TensorObject):
+            _error(f"{selected.object_name}: expected tensor")
+        parent = recipe.materialize_bf16_parent(selected.parts, reader)
+        words = nvfp4_encode.quantize_nvfp4(parent, device=device)
+        stored_packed, stored_scales, stored_divisor = decode_nvfp4_words(
+            artifact.payload(obj), obj.shape
+        )
+        if not torch.equal(stored_packed, words.packed_codes.cpu()):
+            _error(f"{obj.name}: packed E2M1 words differ from the encoder profile")
+        if not torch.equal(stored_scales, words.natural_scales.cpu()):
+            _error(f"{obj.name}: E4M3FN scale words differ from the encoder profile")
+        if stored_divisor.item() != words.weight_divisor:
+            _error(f"{obj.name}: weight divisor differs from the encoder profile")
+        reconstructed = nvfp4_encode.dequantize_nvfp4(
+            nvfp4_encode.Nvfp4Words(
+                packed_codes=stored_packed,
+                natural_scales=stored_scales,
+                weight_divisor=stored_divisor.item(),
+            ),
+            device=device,
+        )
+        error = nvfp4_encode.relative_frobenius_error(parent, reconstructed)
+        if error > 0.25:
+            _error(f"{obj.name}: decode-oracle relative error {error:.4f}")
+        max_error = max(max_error, error)
+        del parent
+    return max_error
+
+
+def _verify_source_input_divisors(
+    artifact: Artifact,
+    reader: ShardReader,
+) -> None:
+    for selected in recipe.SOURCE_INPUT_DIVISOR_RECIPES:
+        obj = artifact.find(selected.object_name)
+        if not isinstance(obj, TensorObject):
+            _error(f"{selected.object_name}: expected tensor")
+        expected = recipe.materialize_source_input_divisor(selected, reader)
+        stored = decode_direct(artifact.payload(obj), obj.format, obj.shape)
+        word = int(stored.view(torch.int32).item()) & 0xFFFFFFFF
+        if not valid_positive_fp32_word(word):
+            _error(f"{obj.name}: input divisor is not finite and positive")
+        if not torch.equal(stored.view(torch.int32), expected.view(torch.int32)):
+            _error(f"{obj.name}: input divisor differs from source")
+
+
+def _verify_local_input_divisors(
+    artifact: Artifact,
+    divisor_table: recipe.LocalDivisorTable,
+) -> None:
+    for selected in recipe.LOCAL_INPUT_DIVISOR_RECIPES:
+        obj = artifact.find(selected.object_name)
+        if not isinstance(obj, TensorObject):
+            _error(f"{selected.object_name}: expected tensor")
+        expected = divisor_table.value(selected.object_name)
+        stored = decode_direct(artifact.payload(obj), obj.format, obj.shape)
+        word = int(stored.view(torch.int32).item()) & 0xFFFFFFFF
+        if not valid_positive_fp32_word(word):
+            _error(f"{obj.name}: input divisor is not finite and positive")
+        if not torch.equal(stored.view(torch.int32), expected.view(torch.int32)):
+            _error(f"{obj.name}: input divisor differs from calibration")
+
+
+def _verify_bf16_exception_matrices(
+    artifact: Artifact,
+    reader: ShardReader,
+) -> None:
+    for selected in recipe.BF16_WEIGHT_RECIPES:
+        obj = artifact.find(selected.object_name)
+        if not isinstance(obj, TensorObject):
+            _error(f"{selected.object_name}: expected tensor")
+        expected = recipe.materialize_bf16_parent(selected.parts, reader)
+        stored = decode_direct(artifact.payload(obj), obj.format, obj.shape)
+        if not torch.equal(stored.view(torch.int16), expected.view(torch.int16)):
+            _error(f"{obj.name}: BF16 words differ from base source")
+
+
+def verify_artifact(
+    artifact: Artifact,
+    base_dir: str | Path,
+    quantized_dir: str | Path,
+    calibration_path: str | Path,
+    *,
+    device: str | torch.device = "cuda",
+) -> VerificationSummary:
+    base = Path(base_dir)
+    quantized = Path(quantized_dir)
+    payload_bytes = validate_structure(artifact)
+    convert.preflight_conversion(base, quantized_dir, calibration_path)
+    divisor_table = recipe.LocalDivisorTable(calibration_path)
+    _verify_resources(artifact, base)
+    with ShardReader(base) as base_reader:
+        w8_endpoint_rows, w8_endpoint_groups = _verify_w8_endpoints(
+            artifact, base_reader
+        )
+        _verify_bf16_exception_matrices(artifact, base_reader)
+        max_error = _verify_local_nvfp4_weights(
+            artifact, base_reader, torch.device(device)
+        )
+    with ShardReader(quantized) as quantized_reader:
+        _verify_source_nvfp4_weights(artifact, quantized_reader)
+        _verify_source_input_divisors(artifact, quantized_reader)
+    _verify_local_input_divisors(artifact, divisor_table)
+    return VerificationSummary(
+        objects=len(artifact.objects),
+        tensors=len(inventory.TENSOR_SPECS),
+        resources=len(inventory.RESOURCE_SPECS),
+        w8_endpoint_weights=len(W8_ENDPOINT_SPECS),
+        w8_endpoint_rows=w8_endpoint_rows,
+        w8_endpoint_groups=w8_endpoint_groups,
+        source_nvfp4_weights=len(recipe.SOURCE_NVFP4_WEIGHT_RECIPES),
+        local_nvfp4_weights=len(recipe.LOCAL_NVFP4_WEIGHT_RECIPES),
+        local_nvfp4_max_relative_error=max_error,
+        bf16_exception_matrices=len(recipe.BF16_WEIGHT_RECIPES),
+        input_divisors_source=len(recipe.SOURCE_INPUT_DIVISOR_RECIPES),
+        input_divisors_local=len(recipe.LOCAL_INPUT_DIVISOR_RECIPES),
+        payload_bytes=payload_bytes,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("artifact", type=Path)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--quantized-model", type=Path, required=True)
+    parser.add_argument("--calibration", type=Path, required=True)
+    parser.add_argument("--device", default="cuda")
+    arguments = parser.parse_args(argv)
+    with Artifact.open(arguments.artifact) as artifact:
+        summary = verify_artifact(
+            artifact,
+            arguments.model,
+            arguments.quantized_model,
+            arguments.calibration,
+            device=arguments.device,
+        )
+    print(json.dumps(asdict(summary), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Cherry-picks the two code commits from cometkim/feat/qwen3.8-nvfp4full onto current master:

- feat(target): register qwen3.8-27b nvfp4full weights profile
- feat(convert): nvfp4full encoder, calibration, converter, and verifier for qwen3.8-27b

Both apply cleanly; no code changes were needed beyond the cherry-pick.

Verified on RTX 5090 Laptop (Windows, Release build):
- Full C++ build: clean, zero errors
- qwen3.8-27b/nvfp4full artifact load + short generation: correct output
- qwen3.8-27b/nvfp4 regression: correct output, no behavior change